### PR TITLE
feat: add align, bone and frame icons

### DIFF
--- a/icons/align-center.tsx
+++ b/icons/align-center.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { motion, useAnimation } from 'framer-motion';
+
+const AlignCenterIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={28}
+        height={28}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M17 12H7"
+          variants={{
+            normal: { translateX: 0 },
+            animate: {
+              translateX: [0, 3, -3, 2, -2, 0],
+              transition: {
+                ease: 'linear',
+                translateX: {
+                  duration: 1,
+                },
+              },
+            },
+          }}
+          animate={controls}
+        />
+        <path d="M19 18H5" />
+        <path d="M21 6H3" />
+      </svg>
+    </div>
+  );
+};
+
+export { AlignCenterIcon };

--- a/icons/align-horizontal-space-around.tsx
+++ b/icons/align-horizontal-space-around.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { motion, Transition, useAnimation } from 'framer-motion';
+
+const defaultTransition: Transition = {
+  type: 'spring',
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const AlignHorizontalSpaceAroundIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={28}
+        height={28}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.rect
+          variants={{
+            normal: { scaleX: 1 },
+            animate: { scaleX: 0.85 },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          width={6}
+          height={10}
+          x={9}
+          y={7}
+          rx={2}
+        />
+        <motion.path
+          d="M4 22V2"
+          variants={{
+            normal: { translateX: 0, scaleY: 1 },
+            animate: {
+              translateX: 2,
+              scaleY: 0.9,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+        />
+        <motion.path
+          d="M20 22V2"
+          variants={{
+            normal: { translateX: 0, scaleY: 1 },
+            animate: {
+              translateX: -2,
+              scaleY: 0.9,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export { AlignHorizontalSpaceAroundIcon };

--- a/icons/align-vertical-space-around.tsx
+++ b/icons/align-vertical-space-around.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { motion, Transition, useAnimation } from 'framer-motion';
+
+const defaultTransition: Transition = {
+  type: 'spring',
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const AlignVerticalSpaceAroundIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={28}
+        height={28}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.rect
+          variants={{
+            normal: { scaleY: 1 },
+            animate: { scaleY: 0.8 },
+          }}
+          animate={controls}
+          width={10}
+          height={6}
+          x={7}
+          y={9}
+          rx={2}
+          transition={defaultTransition}
+        />
+        <motion.path
+          variants={{
+            normal: { translateY: 0, scaleX: 1 },
+            animate: {
+              translateY: -2,
+              scaleX: 0.9,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          d="M22 20H2"
+        />
+        <motion.path
+          variants={{
+            normal: { translateY: 0, scaleX: 1 },
+            animate: {
+              translateY: 2,
+              scaleX: 0.9,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          d="M22 4H2"
+        />
+      </svg>
+    </div>
+  );
+};
+
+export { AlignVerticalSpaceAroundIcon };

--- a/icons/bone.tsx
+++ b/icons/bone.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { motion, useAnimation, Variants } from 'framer-motion';
+
+const variants: Variants = {
+  normal: { rotate: 0 },
+  animate: {
+    rotate: [0, -8, 8, -6, 0],
+    transition: {
+      ease: 'circIn',
+      rotate: {
+        duration: 0.5,
+      },
+    },
+  },
+};
+
+const BoneIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={28}
+        height={28}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          variants={variants}
+          animate={controls}
+          d="M17 10c.7-.7 1.69 0 2.5 0a2.5 2.5 0 1 0 0-5 .5.5 0 0 1-.5-.5 2.5 2.5 0 1 0-5 0c0 .81.7 1.8 0 2.5l-7 7c-.7.7-1.69 0-2.5 0a2.5 2.5 0 0 0 0 5c.28 0 .5.22.5.5a2.5 2.5 0 1 0 5 0c0-.81-.7-1.8 0-2.5Z"
+        />
+      </svg>
+    </div>
+  );
+};
+
+export { BoneIcon };

--- a/icons/frame.tsx
+++ b/icons/frame.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { motion, Transition, useAnimation } from 'framer-motion';
+
+const defaultTransition: Transition = {
+  type: 'spring',
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const FrameIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={28}
+        height={28}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.line
+          variants={{
+            animate: { translateY: -4 },
+            normal: {
+              translateX: 0,
+              rotate: 0,
+              translateY: 0,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          x1={22}
+          x2={2}
+          y1={6}
+          y2={6}
+        />
+        <motion.line
+          variants={{
+            animate: { translateY: 4 },
+            normal: {
+              translateX: 0,
+              rotate: 0,
+              translateY: 0,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          x1={22}
+          x2={2}
+          y1={18}
+          y2={18}
+        />
+        <motion.line
+          variants={{
+            animate: { translateX: -4 },
+            normal: {
+              translateX: 0,
+              rotate: 0,
+              translateY: 0,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          x1={6}
+          x2={6}
+          y1={2}
+          y2={22}
+        />
+        <motion.line
+          variants={{
+            animate: { translateX: 4 },
+            normal: {
+              translateX: 0,
+              rotate: 0,
+              translateY: 0,
+            },
+          }}
+          animate={controls}
+          transition={defaultTransition}
+          x1={18}
+          x2={18}
+          y1={2}
+          y2={22}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export { FrameIcon };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -44,6 +44,11 @@ import { AttachFileIcon } from '@/icons/attach-file';
 import { GaugeIcon } from '@/icons/gauge';
 import { MenuIcon } from '@/icons/menu';
 import { ClockIcon } from '@/icons/clock';
+import { FrameIcon } from '@/icons/frame';
+import { BoneIcon } from '@/icons/bone';
+import { AlignCenterIcon } from '@/icons/align-center';
+import { AlignVerticalSpaceAroundIcon } from '@/icons/align-vertical-space-around';
+import { AlignHorizontalSpaceAroundIcon } from '@/icons/align-horizontal-space-around';
 
 const ICON_LIST = [
   { name: 'home', icon: HomeIcon },
@@ -92,6 +97,14 @@ const ICON_LIST = [
   { name: 'volume', icon: VolumeIcon },
   { name: 'sun', icon: SunIcon },
   { name: 'party-popper', icon: PartyPopperIcon },
+  { name: 'frame', icon: FrameIcon },
+  { name: 'bone', icon: BoneIcon },
+  { name: 'align-center', icon: AlignCenterIcon },
+  { name: 'align-vertical-space-around', icon: AlignVerticalSpaceAroundIcon },
+  {
+    name: 'align-horizontal-space-around',
+    icon: AlignHorizontalSpaceAroundIcon,
+  },
 ];
 
 export { ICON_LIST };


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add new icons: bone, frame, align-center, align-vertical-space-around, align-horizontal-space-around

## What is the new behavior?

N/A

## Demo

- bone icon:

https://github.com/user-attachments/assets/724636cf-fdc9-42a3-b7d5-545aaec6cf59

- Frame icon:

https://github.com/user-attachments/assets/3e727a2c-d40a-4628-97ea-b9197898b454

- Align icons:

https://github.com/user-attachments/assets/127cc75b-f14b-4401-a124-540fb5498d88


## Additional context

N/A
