### PR TITLE
fix: change the path direction

### DIFF
--- a/icons/check-check.tsx
+++ b/icons/check-check.tsx
@@ -49,14 +49,14 @@ const CheckCheckIcon = () => {
           variants={pathVariants}
           initial="normal"
           animate={controls}
-          d="M18 6 7 17l-5-5"
+          d="M2 12 7 17L18 6"
           custom={0}
         />
         <motion.path
           variants={pathVariants}
           initial="normal"
           animate={controls}
-          d="m22 10-7.5 7.5L13 16"
+          d="M13 16L14.5 17.5L22 10"
           custom={1}
         />
       </svg>

--- a/icons/check.tsx
+++ b/icons/check.tsx
@@ -48,7 +48,7 @@ const CheckIcon = () => {
           variants={pathVariants}
           initial="normal"
           animate={controls}
-          d="M20 6 9 17l-5-5"
+          d="M4 12 9 17L20 6"
         />
       </svg>
     </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the new behavior?

the starting point of the path of the original icon (`CheckIcon` and  `CheckCheckIcon`) is at the upper right corner (the long side vertex of the ✓)

this pr reverse it. 

![image](https://github.com/user-attachments/assets/8fa53867-4602-43a2-9e07-b20f00a4b020)

![image](https://github.com/user-attachments/assets/31ec3d78-4a66-4d5f-b4fd-27117c754f95)
