### PR TITLE
fix: change the exported module names of circle-chevron series

### DIFF
--- a/icons/circle-chevron-down.tsx
+++ b/icons/circle-chevron-down.tsx
@@ -8,7 +8,7 @@ const defaultTransition: Transition = {
   duration: 0.5,
 };
 
-const CircleChevronDown = () => {
+const CircleChevronDownIcon = () => {
   const controls = useAnimation();
 
   return (
@@ -45,4 +45,4 @@ const CircleChevronDown = () => {
   );
 };
 
-export { CircleChevronDown };
+export { CircleChevronDownIcon };

--- a/icons/circle-chevron-left.tsx
+++ b/icons/circle-chevron-left.tsx
@@ -8,7 +8,7 @@ const defaultTransition: Transition = {
   duration: 0.5,
 };
 
-const CircleChevronLeft = () => {
+const CircleChevronLeftIcon = () => {
   const controls = useAnimation();
 
   return (
@@ -43,4 +43,4 @@ const CircleChevronLeft = () => {
   );
 };
 
-export { CircleChevronLeft };
+export { CircleChevronLeftIcon };

--- a/icons/circle-chevron-right.tsx
+++ b/icons/circle-chevron-right.tsx
@@ -8,7 +8,7 @@ const defaultTransition: Transition = {
   duration: 0.5,
 };
 
-const CircleChevronRight = () => {
+const CircleChevronRightIcon = () => {
   const controls = useAnimation();
 
   return (
@@ -43,4 +43,4 @@ const CircleChevronRight = () => {
   );
 };
 
-export { CircleChevronRight };
+export { CircleChevronRightIcon };

--- a/icons/circle-chevron-up.tsx
+++ b/icons/circle-chevron-up.tsx
@@ -8,7 +8,7 @@ const defaultTransition: Transition = {
   duration: 0.5,
 };
 
-const CircleChevronUp = () => {
+const CircleChevronUpIcon = () => {
   const controls = useAnimation();
 
   return (
@@ -45,4 +45,4 @@ const CircleChevronUp = () => {
   );
 };
 
-export { CircleChevronUp };
+export { CircleChevronUpIcon };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -81,10 +81,10 @@ import { ChevronsUpDownIcon } from '@/icons/chevrons-up-down';
 import { ChevronsDownUpIcon } from '@/icons/chevrons-down-up';
 import { ChevronsLeftRightIcon } from '@/icons/chevrons-left-right';
 import { ChevronsRightLeftIcon } from '@/icons/chevrons-right-left';
-import { CircleChevronDown } from '@/icons/circle-chevron-down';
-import { CircleChevronLeft } from '@/icons/circle-chevron-left';
-import { CircleChevronRight } from '@/icons/circle-chevron-right';
-import { CircleChevronUp } from '@/icons/circle-chevron-up';
+import { CircleChevronDownIcon } from '@/icons/circle-chevron-down';
+import { CircleChevronLeftIcon } from '@/icons/circle-chevron-left';
+import { CircleChevronRightIcon } from '@/icons/circle-chevron-right';
+import { CircleChevronUpIcon } from '@/icons/circle-chevron-up';
 import { CheckIcon } from '@/icons/check';
 import { CheckCheckIcon } from '@/icons/check-check';
 import { IdCardIcon } from '@/icons/id-card';
@@ -749,12 +749,12 @@ const ICON_LIST: IconListItem[] = [
   },
   {
     name: 'circle-chevron-down',
-    icon: CircleChevronDown,
+    icon: CircleChevronDownIcon,
     keywords: ['back', 'menu', 'chevron'],
   },
   {
     name: 'circle-chevron-left',
-    icon: CircleChevronLeft,
+    icon: CircleChevronLeftIcon,
     keywords: [
       'back',
       'previous',
@@ -767,7 +767,7 @@ const ICON_LIST: IconListItem[] = [
   },
   {
     name: 'circle-chevron-right',
-    icon: CircleChevronRight,
+    icon: CircleChevronRightIcon,
     keywords: [
       'next',
       'forward',
@@ -780,7 +780,7 @@ const ICON_LIST: IconListItem[] = [
   },
   {
     name: 'circle-chevron-up',
-    icon: CircleChevronUp,
+    icon: CircleChevronUpIcon,
     keywords: ['caret', 'ahead', 'forward', 'menu', 'chevron'],
   },
   {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the new behavior?

change the exported module names of circle-chevron series. make the name end with `Icon`.

