### PR TITLE
fix: card style

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -19,7 +19,7 @@ const ACTION_CLASS_NAMES =
 
 const Card = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="p-3 border w-full h-full border-input rounded-md flex items-center justify-center flex-col">
+    <div className="p-3 border border-input rounded-md flex items-center justify-center flex-col">
       {children}
     </div>
   );


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

fix

## What is the new behavior?

iOS / Mac safari the card display is different from Mac chrome, like the pic👇

## Additional context

![image](https://github.com/user-attachments/assets/abdae0a3-f7b8-4e72-8ee2-eb8a47dd1d5c)
