### PR TITLE
Add chart-scatter icon & battery-full icon

### DIFF
--- a/icons/battery-full.tsx
+++ b/icons/battery-full.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type Variants, motion, useAnimation } from 'framer-motion';
+import { type Variants, motion, useAnimation } from 'motion/react';
 
 const lineVariants: Variants = {
   initial: { opacity: 1 },

--- a/icons/battery-full.tsx
+++ b/icons/battery-full.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { type Variants, motion, useAnimation } from 'framer-motion';
+
+const lineVariants: Variants = {
+  initial: { opacity: 1 },
+  fadeOut: {
+    opacity: 0,
+    transition: {
+      duration: 0.4,
+      ease: "easeInOut"
+    }
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      duration: 0.6,
+      delay: i * 0.4,
+      ease: "easeInOut"
+    }
+  })
+};
+
+const BatteryFullIcon = () => {
+  const controls = useAnimation();
+
+  const handleHoverStart = async () => {
+    await controls.start("fadeOut");
+    controls.start("fadeIn");
+  };
+
+  const handleHoverEnd = () => {
+    controls.start("initial");
+  };
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={handleHoverStart}
+      onMouseLeave={handleHoverEnd}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <rect width="16" height="10" x="2" y="7" rx="2" ry="2" />
+        <line x1="22" x2="22" y1="11" y2="13" />
+        <motion.line
+          x1="6"
+          x2="6"
+          y1="11"
+          y2="13"
+          variants={lineVariants}
+          initial="initial"
+          animate={controls}
+          custom={0}
+        />
+        <motion.line
+          x1="10"
+          x2="10"
+          y1="11"
+          y2="13"
+          variants={lineVariants}
+          initial="initial"
+          animate={controls}
+          custom={1}
+        />
+        <motion.line
+          x1="14"
+          x2="14"
+          y1="11"
+          y2="13"
+          variants={lineVariants}
+          initial="initial"
+          animate={controls}
+          custom={2}
+        />
+      </motion.svg>
+    </div>
+  );
+};
+
+export { BatteryFullIcon };

--- a/icons/chart-scatter.tsx
+++ b/icons/chart-scatter.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { type Variants, motion, useAnimation } from 'framer-motion';
+
+const dotVariants: Variants = {
+  visible: (i: number) => ({
+    scale: 1,
+    opacity: 1,
+    transition: {
+      delay: i * 0.15,
+      duration: 0.3,
+    },
+  }),
+  hidden: { 
+    scale: 1, 
+    opacity: 0,
+    transition: {
+      duration: 0.2,
+    },
+  },
+  default: { scale: 1, opacity: 1 }
+};
+
+const ChartScatterIcon = () => {
+  const controls = useAnimation();
+
+  const handleHoverStart = async () => {
+    await controls.start('hidden');
+    await controls.start('visible');
+  };
+
+  const handleHoverEnd = async () => {
+    await controls.start('default');
+  };
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={handleHoverStart}
+      onMouseLeave={handleHoverEnd}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        initial="default"
+        animate={controls}
+      >
+        <motion.circle cx="7.5" cy="7.5" r=".5" variants={dotVariants} custom={0} fill="currentColor"/>
+        <motion.circle cx="18.5" cy="5.5" r=".5" variants={dotVariants} custom={1} fill="currentColor"/>
+        <motion.circle cx="11.5" cy="11.5" r=".5" variants={dotVariants} custom={2} fill="currentColor"/>
+        <motion.circle cx="7.5" cy="16.5" r=".5" variants={dotVariants} custom={3} fill="currentColor"/>
+        <motion.circle cx="17.5" cy="14.5" r=".5" variants={dotVariants} custom={4} fill="currentColor"/>
+        <path
+          d="M3 3v16a2 2 0 0 0 2 2h16"
+          strokeWidth="2"
+        />
+      </motion.svg>
+    </div>
+  );
+};
+
+export { ChartScatterIcon };

--- a/icons/chart-scatter.tsx
+++ b/icons/chart-scatter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type Variants, motion, useAnimation } from 'framer-motion';
+import { type Variants, motion, useAnimation } from 'motion/react';
 
 const dotVariants: Variants = {
   visible: (i: number) => ({
@@ -11,8 +11,8 @@ const dotVariants: Variants = {
       duration: 0.3,
     },
   }),
-  hidden: { 
-    scale: 1, 
+  hidden: {
+    scale: 1,
     opacity: 0,
     transition: {
       duration: 0.2,

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -117,6 +117,7 @@ import { CogIcon } from '@/icons/cog';
 import { CpuIcon } from '@/icons/cpu';
 import { RocketIcon } from '@/icons/rocket';
 import { ActivityIcon } from '@/icons/activity';
+import { BatteryFullIcon } from '@/icons/battery-full';
 
 type IconListItem = {
   name: string;
@@ -1121,6 +1122,11 @@ const ICON_LIST: IconListItem[] = [
     name: 'ban',
     icon: BanIcon,
     keywords: ['ban', 'stop', 'prevent', 'no'],
+  },
+  {
+    name: 'battery-full',
+    icon: BatteryFullIcon,
+    keywords: ['battery', 'power', 'energy', 'full', 'charge'],
   },
 ];
 

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -13,6 +13,7 @@ import { BoldIcon } from '@/icons/bold';
 import { BoneIcon } from '@/icons/bone';
 import { CalendarCogIcon } from '@/icons/calendar-cog';
 import { ChartPieIcon } from '@/icons/chart-pie';
+import { ChartScatterIcon } from '@/icons/chart-scatter';
 import { CircleCheckIcon } from '@/icons/circle-check';
 import { CircleDollarSignIcon } from '@/icons/circle-dollar-sign';
 import { ClockIcon } from '@/icons/clock';
@@ -538,6 +539,11 @@ const ICON_LIST: IconListItem[] = [
     name: 'chart-pie',
     icon: ChartPieIcon,
     keywords: ['statistics', 'analytics', 'diagram', 'presentation'],
+  },
+  {
+    name: 'chart-scatter',
+    icon: ChartScatterIcon,
+    keywords: ['chart', 'analytics', 'scatter'],
   },
   {
     name: 'gauge',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add chart-scatter icon & battery-full icon

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Demo

https://github.com/user-attachments/assets/578e7597-7af9-4f2f-a97a-3e2e0b6a1f6b

## Additional context

Add any other context or screenshots.
