### PR TITLE
fix: airplane animation

### DIFF
--- a/icons/airplane.tsx
+++ b/icons/airplane.tsx
@@ -3,9 +3,9 @@
 import { motion, useAnimation } from 'motion/react';
 
 const SPEED_LINES = [
-  { x1: -6, y1: 26, x2: 0, y2: 20, delay: 0.1 },
-  { x1: -4, y1: 28, x2: 2, y2: 22, delay: 0.2 },
-  { x1: -2, y1: 30, x2: 4, y2: 24, delay: 0.3 },
+  { x1: 5, y1: 15, x2: 1, y2: 19, delay: 0.1 },
+  { x1: 7, y1: 17, x2: 3, y2: 21, delay: 0.2 },
+  { x1: 9, y1: 19, x2: 5, y2: 23, delay: 0.3 },
 ];
 
 const AirplaneIcon = () => {
@@ -14,36 +14,39 @@ const AirplaneIcon = () => {
   return (
     <div
       className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
-      onMouseEnter={() => controls.start('hover')}
-      onMouseLeave={() => controls.start('initial')}
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
     >
-      <motion.svg
+      <svg
         xmlns="http://www.w3.org/2000/svg"
         width="28"
         height="28"
-        viewBox="-6 0 34 30"
+        viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        animate={controls}
-        transition={{
-          duration: 0.5,
-          times: [0, 0.6, 1],
-          type: 'spring',
-          stiffness: 200,
-          damping: 10,
-        }}
-        variants={{
-          initial: { x: 0, y: 0 },
-          hover: {
-            x: [0, 5, 3],
-            y: [0, -5, -3],
-          },
-        }}
       >
-        <path d="M17.8 19.2L16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z" />
+        <motion.path
+          animate={controls}
+          transition={{
+            duration: 0.5,
+            times: [0, 0.6, 1],
+            type: 'spring',
+            stiffness: 200,
+            damping: 10,
+          }}
+          variants={{
+            normal: { x: 0, y: 0, scale: 1 },
+            animate: {
+              x: [0, 5, 3],
+              y: [0, -5, -3],
+              scale: 0.8,
+            },
+          }}
+          d="M17.8 19.2L16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z"
+        />
         {SPEED_LINES.map((line, index) => (
           <motion.line
             key={index}
@@ -53,15 +56,33 @@ const AirplaneIcon = () => {
             y2={line.y2}
             stroke="currentColor"
             strokeWidth={1}
-            initial={{ pathLength: 0, opacity: 0 }}
+            initial={{ opacity: 0, pathLength: 1, pathSpacing: 1 }}
             variants={{
-              initial: { pathLength: 0, opacity: 0 },
-              hover: { pathLength: 1, opacity: 1 },
+              normal: {
+                pathOffset: [0, 1],
+                translateX: -3,
+                translateY: 3,
+                opacity: 0,
+                transition: {
+                  duration: 0.3,
+                  times: [0, 0.6, 1],
+                  type: 'spring',
+                  stiffness: 200,
+                  damping: 10,
+                },
+              },
+              animate: {
+                pathOffset: [1, 2],
+                translateX: [0, 0],
+                translateY: [0, 0],
+                opacity: 1,
+              },
             }}
-            transition={{ duration: 0.3, delay: line.delay }}
+            transition={{ duration: 0.15, delay: line.delay }}
+            animate={controls}
           />
         ))}
-      </motion.svg>
+      </svg>
     </div>
   );
 };


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the new behavior?

1. `svg` tag remove animation, `path` (airplane) add animation `x,y,scale` (scale is newly added, because if only `x,y` changes, the airplane path will be partially blocked)
2. use `viewBox="0 0 24 24"`, i think we should not change this attribute. the `viewBox` `width` `height` attributes of the most of icons's `svg` tag  should be fixed. there are only two icons that are exceptions now, `flask` and `syringe`, they are `viewBox="0 0 512 512"`. 
3. change animation direction of `line` by `pathOffset`
4. use `animate` and `normal` key name

