### PR TITLE
feat: add arrow-down series icon

### DIFF
--- a/icons/arrow-down-0-1.tsx
+++ b/icons/arrow-down-0-1.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import type { Transition } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+
+const swapTransition: Transition = {
+  type: 'spring',
+  stiffness: 240,
+  damping: 24,
+};
+
+const ArrowDown01con = () => {
+  const controls = useAnimation();
+
+  const swapVariants = {
+    normal: {
+      translateY: 0,
+    },
+    animate: (custom: number) => ({
+      translateY: custom * 10,
+    }),
+  };
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m3 16 4 4 4-4" />
+        <path d="M7 20V4" />
+        <motion.rect
+          x="15"
+          y="4"
+          width="4"
+          height="6"
+          ry="2"
+          variants={swapVariants}
+          initial="normal"
+          animate={controls}
+          custom={1}
+          transition={swapTransition}
+        />
+        <motion.g
+          variants={swapVariants}
+          initial="normal"
+          animate={controls}
+          custom={-1}
+          transition={swapTransition}
+        >
+          <path d="M17 20v-6h-2" />
+          <path d="M15 20h4" />
+        </motion.g>
+      </svg>
+    </div>
+  );
+};
+
+export { ArrowDown01con };

--- a/icons/arrow-down-a-z.tsx
+++ b/icons/arrow-down-a-z.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { Transition } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+
+const swapTransition: Transition = {
+  type: 'spring',
+  stiffness: 240,
+  damping: 24,
+};
+
+const ArrowDownAZIcon = () => {
+  const controls = useAnimation();
+
+  const swapVariants = {
+    normal: {
+      translateY: 0,
+    },
+    animate: (custom: number) => ({
+      translateY: custom * 10,
+    }),
+  };
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m3 16 4 4 4-4" />
+        <path d="M7 20V4" />
+        <motion.g
+          variants={swapVariants}
+          initial="normal"
+          animate={controls}
+          custom={1}
+          transition={swapTransition}
+        >
+          <path d="M20 8h-5" />
+          <path d="M15 10V6.5a2.5 2.5 0 0 1 5 0V10" />
+        </motion.g>
+        <motion.path
+          d="M15 14h5l-5 6h5"
+          variants={swapVariants}
+          initial="normal"
+          animate={controls}
+          custom={-1}
+          transition={swapTransition}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export { ArrowDownAZIcon };

--- a/icons/arrow-down-z-a.tsx
+++ b/icons/arrow-down-z-a.tsx
@@ -40,24 +40,24 @@ const ArrowDownZAIcon = () => {
       >
         <path d="m3 16 4 4 4-4" />
         <path d="M7 20V4" />
-        <motion.g
+        <motion.path
+          d="M15 4h5l-5 6h5"
           variants={swapVariants}
           initial="normal"
           animate={controls}
           custom={1}
           transition={swapTransition}
-        >
-          <path d="M20 8h-5" />
-          <path d="M15 10V6.5a2.5 2.5 0 0 1 5 0V10" />
-        </motion.g>
-        <motion.path
-          d="M15 14h5l-5 6h5"
+        />
+        <motion.g
           variants={swapVariants}
           initial="normal"
           animate={controls}
           custom={-1}
           transition={swapTransition}
-        />
+        >
+          <path d="M20 18h-5" />
+          <path d="M15 20v-3.5a2.5 2.5 0 0 1 5 0V20" />
+        </motion.g>
       </svg>
     </div>
   );

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -142,6 +142,8 @@ import { WindIcon } from '@/icons/wind';
 import { CctvIcon } from '@/icons/cctv';
 import { CoffeeIcon } from '@/icons/coffee';
 import { ArrowDownZAIcon } from '@/icons/arrow-down-z-a';
+import { ArrowDownAZIcon } from '@/icons/arrow-down-a-z';
+import { ArrowDown01con } from '@/icons/arrow-down-0-1';
 import { ArrowDown10con } from '@/icons/arrow-down-1-0';
 
 type IconListItem = {
@@ -1437,6 +1439,21 @@ const ICON_LIST: IconListItem[] = [
     ],
   },
   {
+    name: 'arrow-down-a-z',
+    icon: ArrowDownAZIcon,
+    keywords: [
+      'filter',
+      'sort',
+      'ascending',
+      'descending',
+      'increasing',
+      'decreasing',
+      'rising',
+      'falling',
+      'alphabetical',
+    ],
+  },
+  {
     name: 'arrow-down-z-a',
     icon: ArrowDownZAIcon,
     keywords: [
@@ -1449,6 +1466,21 @@ const ICON_LIST: IconListItem[] = [
       'rising',
       'falling',
       'alphabetical',
+    ],
+  },
+  {
+    name: 'arrow-down-0-1',
+    icon: ArrowDown01con,
+    keywords: [
+      'filter',
+      'sort',
+      'ascending',
+      'descending',
+      'increasing',
+      'decreasing',
+      'rising',
+      'falling',
+      'numerical',
     ],
   },
   {

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -65,8 +65,20 @@ export const components: ComponentDefinition[] = [
     'dependencies': ['motion'],
   },
   {
+    'name': 'arrow-down-0-1',
+    'path': path.join(__dirname, '../icons/arrow-down-0-1.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
     'name': 'arrow-down-1-0',
     'path': path.join(__dirname, '../icons/arrow-down-1-0.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'arrow-down-a-z',
+    'path': path.join(__dirname, '../icons/arrow-down-a-z.tsx'),
     'registryDependencies': [],
     'dependencies': ['motion'],
   },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

feat: add arrow-down-a-z arrow-down-0-1
fix: arrow-down-z-a

## What is the new behavior?

![image](https://github.com/user-attachments/assets/8427132c-d57d-4bb9-ab15-7d1057de7d95)

arrow-down-z-a icon, the z should be above a as lucide icon
![image](https://github.com/user-attachments/assets/d7156936-67be-4946-87f6-dfdf1852bbaf)

and add arrow-down-a-z arrow-down-0-1 icons

it need to rebuild, because i don't execute `build:registry`

