### PR TITLE
fix: update CLI command to use latest version of shadcn

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -72,7 +72,7 @@ const Actions = ({ content, name }: Icon) => {
   const handleCopyTerminal = () => {
     op.track(ANALYTIC_EVENT.ICON_COPY_TERMINAL, { icon: `${name}.tsx` });
     navigator.clipboard.writeText(
-      `npx shadcn add "https://icons.pqoqubbw.dev/c/${name}.json"`
+      `npx shadcn@latest add "https://icons.pqoqubbw.dev/c/${name}.json"`
     );
     setCopiedTerminal(true);
     setTimeout(() => setCopiedTerminal(false), 2000);

--- a/components/cli-block/index.tsx
+++ b/components/cli-block/index.tsx
@@ -15,7 +15,7 @@ const CliBlock = ({ icons }: { icons: Icon[] }) => {
     const text = currentIconName.current || icons[0].name;
     try {
       await navigator.clipboard.writeText(
-        `npx shadcn add "https://icons.pqoqubbw.dev/c/${text}.json"`
+        `npx shadcn@latest add "https://icons.pqoqubbw.dev/c/${text}.json"`
       );
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
@@ -33,7 +33,7 @@ const CliBlock = ({ icons }: { icons: Icon[] }) => {
         <div className="flex items-center min-w-0">
           <span className="shrink-0 mr-2">npx</span>{' '}
           <span className="text-muted-foreground shrink-0">
-            shadcn add &quot;https://icons.pqoqubbw.dev/c/
+            shadcn@latest add &quot;https://icons.pqoqubbw.dev/c/
           </span>
           <TextLoop
             onIndexChange={(index) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

NO, not required

## What kind of change does this PR introduce?
Fix

## What is the new behavior?
Shadcn command changed from `npx shadcn add` to `npx shadcn@latest`
