### PR TITLE
feat: added animated upload icon

### DIFF
--- a/icons/index.ts
+++ b/icons/index.ts
@@ -157,6 +157,7 @@ import { MoonIcon } from '@/icons/moon';
 import { VibrateIcon } from '@/icons/vibrate';
 import { SmartphoneChargingIcon } from '@/icons/smartphone-charging';
 import { CastIcon } from '@/icons/cast';
+import { UploadIcon } from '@/icons/upload';
 
 type IconListItem = {
   name: string;
@@ -1575,6 +1576,11 @@ const ICON_LIST: IconListItem[] = [
     name: 'cast',
     icon: CastIcon,
     keywords: ['cast', 'screen', 'chromecast', 'airplay'],
+  },
+  {
+    name: 'upload',
+    icon: UploadIcon,
+    keywords: ['upload', 'send', 'share'],
   },
 ];
 

--- a/icons/upload.tsx
+++ b/icons/upload.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+
+const arrowVariants: Variants = {
+  normal: { y: 0 },
+  animate: {
+    y: -2,
+    transition: {
+      type: 'spring',
+      stiffness: 200,
+      damping: 10,
+      mass: 1,
+    },
+  },
+};
+
+const UploadIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <motion.g variants={arrowVariants} animate={controls}>
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" x2="12" y1="3" y2="15" />
+        </motion.g>
+      </svg>
+    </div>
+  );
+};
+
+export { UploadIcon };

--- a/public/c/upload.json
+++ b/public/c/upload.json
@@ -1,0 +1,21 @@
+{
+  "name": "upload",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "upload.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\n\nconst arrowVariants: Variants = {\n  normal: { y: 0 },\n  animate: {\n    y: -2,\n    transition: {\n      type: 'spring',\n      stiffness: 200,\n      damping: 10,\n      mass: 1,\n    },\n  },\n};\n\nconst UploadIcon = () => {\n  const controls = useAnimation();\n\n  return (\n    <div\n      className=\"cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center\"\n      onMouseEnter={() => controls.start('animate')}\n      onMouseLeave={() => controls.start('normal')}\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        width=\"28\"\n        height=\"28\"\n        viewBox=\"0 0 24 24\"\n        fill=\"none\"\n        stroke=\"currentColor\"\n        strokeWidth=\"2\"\n        strokeLinecap=\"round\"\n        strokeLinejoin=\"round\"\n      >\n        <path d=\"M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4\" />\n        <motion.g variants={arrowVariants} animate={controls}>\n          <polyline points=\"17 8 12 3 7 8\" />\n          <line x1=\"12\" x2=\"12\" y1=\"3\" y2=\"15\" />\n        </motion.g>\n      </svg>\n    </div>\n  );\n};\n\nexport { UploadIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -969,5 +969,11 @@ export const components: ComponentDefinition[] = [
     'path': path.join(__dirname, '../icons/clipboard-check.tsx'),
     'registryDependencies': [],
     'dependencies': ['motion'],
+  },
+  {
+    'name': 'upload',
+    'path': path.join(__dirname, '../icons/upload.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
   }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

Add Upload Icon

## What is the new behavior?

<img width="250" alt="image" src="https://github.com/user-attachments/assets/5c11aa36-b267-45b5-9878-759ac3cbc200" />

## Demo

[upload.webm](https://github.com/user-attachments/assets/ba5ca679-e319-4dee-b9d5-911d01fcc35c)



