### PR TITLE
5 new chart icons added, based on existing similar ones

### DIFF
--- a/icons/chart-line.tsx
+++ b/icons/chart-line.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ChartLineIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChartLineIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const variants: Variants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      delay: 0.15,
+      duration: 0.3,
+      opacity: { delay: 0.1 },
+    },
+  },
+};
+
+const ChartLineIcon = forwardRef<ChartLineIconHandle, ChartLineIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M3 3v16a2 2 0 0 0 2 2h16" />
+          <motion.path
+            d="m7 13 3-3 4 4 5-5"
+            variants={variants}
+            animate={controls}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+ChartLineIcon.displayName = 'ChartLineIcon';
+
+export { ChartLineIcon };

--- a/icons/chart-no-axes-column-decreasing.tsx
+++ b/icons/chart-no-axes-column-decreasing.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { type Variants, motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ChartNoAxesColumnDecreasingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChartNoAxesColumnDecreasingIconProps
+  extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const lineVariants: Variants = {
+  visible: { pathLength: 1, opacity: 1 },
+  hidden: { pathLength: 0, opacity: 0 },
+};
+
+const ChartNoAxesColumnDecreasingIcon = forwardRef<
+  ChartNoAxesColumnDecreasingIconHandle,
+  ChartNoAxesColumnDecreasingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+
+    return {
+      startAnimation: async () => {
+        await controls.start((i) => ({
+          pathLength: 0,
+          opacity: 0,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+        await controls.start((i) => ({
+          pathLength: 1,
+          opacity: 1,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+      },
+      stopAnimation: () => controls.start('visible'),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    async (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        await controls.start((i) => ({
+          pathLength: 0,
+          opacity: 0,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+        await controls.start((i) => ({
+          pathLength: 1,
+          opacity: 1,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('visible');
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn(
+        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+        className
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          variants={lineVariants}
+          initial="visible"
+          animate={controls}
+          custom={0}
+          d="M6 20V4"
+        />
+        <motion.path
+          variants={lineVariants}
+          initial="visible"
+          animate={controls}
+          custom={1}
+          d="M12 20V10"
+        />
+        <motion.path
+          variants={lineVariants}
+          initial="visible"
+          animate={controls}
+          custom={2}
+          d="M18 20v-4"
+        />
+      </svg>
+    </div>
+  );
+});
+
+ChartNoAxesColumnDecreasingIcon.displayName = 'ChartNoAxesColumnDecreasingIcon';
+
+export { ChartNoAxesColumnDecreasingIcon };

--- a/icons/chart-no-axes-column-increasing.tsx
+++ b/icons/chart-no-axes-column-increasing.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { type Variants, motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ChartNoAxesColumnIncreasingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChartNoAxesColumnIncreasingIconProps
+  extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const lineVariants: Variants = {
+  visible: { pathLength: 1, opacity: 1 },
+  hidden: { pathLength: 0, opacity: 0 },
+};
+
+const ChartNoAxesColumnIncreasingIcon = forwardRef<
+  ChartNoAxesColumnIncreasingIconHandle,
+  ChartNoAxesColumnIncreasingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+
+    return {
+      startAnimation: async () => {
+        await controls.start((i) => ({
+          pathLength: 0,
+          opacity: 0,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+        await controls.start((i) => ({
+          pathLength: 1,
+          opacity: 1,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+      },
+      stopAnimation: () => controls.start('visible'),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    async (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        await controls.start((i) => ({
+          pathLength: 0,
+          opacity: 0,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+        await controls.start((i) => ({
+          pathLength: 1,
+          opacity: 1,
+          transition: { delay: i * 0.1, duration: 0.3 },
+        }));
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('visible');
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn(
+        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+        className
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          variants={lineVariants}
+          initial="visible"
+          animate={controls}
+          custom={0}
+          d="M6 20v-4"
+        />
+        <motion.path
+          variants={lineVariants}
+          initial="visible"
+          animate={controls}
+          custom={1}
+          d="M12 20v-10"
+        />
+        <motion.path
+          variants={lineVariants}
+          initial="visible"
+          animate={controls}
+          custom={2}
+          d="M18 20v-16"
+        />
+      </svg>
+    </div>
+  );
+});
+
+ChartNoAxesColumnIncreasingIcon.displayName = 'ChartNoAxesColumnIncreasingIcon';
+
+export { ChartNoAxesColumnIncreasingIcon };

--- a/icons/chart-spline.tsx
+++ b/icons/chart-spline.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ChartSplineIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChartSplineIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const variants: Variants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      delay: 0.15,
+      duration: 0.3,
+      opacity: { delay: 0.1 },
+    },
+  },
+};
+
+const ChartSplineIcon = forwardRef<ChartSplineIconHandle, ChartSplineIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M3 3v16a2 2 0 0 0 2 2h16" />
+          <motion.path
+            d="M7 16c.5-2 1.5-7 4-7 2 0 2 3 4 3 2.5 0 4.5-5 5-7"
+            variants={variants}
+            animate={controls}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+ChartSplineIcon.displayName = 'ChartSplineIcon';
+
+export { ChartSplineIcon };

--- a/icons/file-chart-line.tsx
+++ b/icons/file-chart-line.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface FileChartLineIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface FileChartLineIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const variants: Variants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      delay: 0.15,
+      duration: 0.3,
+      opacity: { delay: 0.1 },
+    },
+  },
+};
+
+const FileChartLineIcon = forwardRef<
+  FileChartLineIconHandle,
+  FileChartLineIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+
+    return {
+      startAnimation: () => controls.start('animate'),
+      stopAnimation: () => controls.start('normal'),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('animate');
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('normal');
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn(
+        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+        className
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+        <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+        <motion.path
+          d="m8 17 2.5-2.5 2 2L16 13"
+          variants={variants}
+          animate={controls}
+        />
+      </svg>
+    </div>
+  );
+});
+
+FileChartLineIcon.displayName = 'FileChartLineIcon';
+
+export { FileChartLineIcon };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -173,6 +173,11 @@ import { MessageCircleDashedIcon } from '@/icons/message-circle-dashed';
 import { MessageSquareDashedIcon } from '@/icons/message-square-dashed';
 import { FileCogIcon } from '@/icons/file-cog';
 import { CalendarDaysIcon } from '@/icons/calendar-days';
+import { ChartLineIcon } from './chart-line';
+import { ChartSplineIcon } from './chart-spline';
+import { FileChartLineIcon } from './file-chart-line';
+import { ChartNoAxesColumnIncreasingIcon } from './chart-no-axes-column-increasing';
+import { ChartNoAxesColumnDecreasingIcon } from './chart-no-axes-column-decreasing';
 
 type IconListItem = {
   name: string;
@@ -1718,6 +1723,45 @@ const ICON_LIST: IconListItem[] = [
     name: 'calendar-days',
     icon: CalendarDaysIcon,
     keywords: ['calendar', 'days', 'days of the week', 'week', 'month'],
+  },
+  {
+    name: 'chart-line',
+    icon: ChartLineIcon,
+    keywords: ['chart', 'line', 'increasing', 'linechart', 'chartline'],
+  },
+  {
+    name: 'chart-spline',
+    icon: ChartSplineIcon,
+    keywords: [
+      'chart',
+      'spline',
+      'increasing',
+      'splinechart',
+      'chartspline',
+      'line',
+    ],
+  },
+  {
+    name: 'file-chart-line',
+    icon: FileChartLineIcon,
+    keywords: [
+      'file',
+      'chart',
+      'line',
+      'increasing',
+      'filechartline',
+      'filechartline',
+    ],
+  },
+  {
+    name: 'chart-no-axes-column-increasing',
+    icon: ChartNoAxesColumnIncreasingIcon,
+    keywords: ['chart', 'column', 'increasing', 'chartnoaxes'],
+  },
+  {
+    name: 'chart-no-axes-column-decreasing',
+    icon: ChartNoAxesColumnDecreasingIcon,
+    keywords: ['chart', 'column', 'decreasing', 'chartnoaxes'],
   },
 ];
 

--- a/public/c/chart-line.json
+++ b/public/c/chart-line.json
@@ -1,0 +1,21 @@
+{
+  "name": "chart-line",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "chart-line.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface ChartLineIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface ChartLineIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst variants: Variants = {\n  normal: {\n    pathLength: 1,\n    opacity: 1,\n  },\n  animate: {\n    pathLength: [0, 1],\n    opacity: [0, 1],\n    transition: {\n      delay: 0.15,\n      duration: 0.3,\n      opacity: { delay: 0.1 },\n    },\n  },\n};\n\nconst ChartLineIcon = forwardRef<ChartLineIconHandle, ChartLineIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <path d=\"M3 3v16a2 2 0 0 0 2 2h16\" />\n          <motion.path\n            d=\"m7 13 3-3 4 4 5-5\"\n            variants={variants}\n            animate={controls}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nChartLineIcon.displayName = 'ChartLineIcon';\n\nexport { ChartLineIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/chart-no-axes-column-decreasing.json
+++ b/public/c/chart-no-axes-column-decreasing.json
@@ -1,0 +1,21 @@
+{
+  "name": "chart-no-axes-column-decreasing",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "chart-no-axes-column-decreasing.tsx",
+      "content": "'use client';\n\nimport { type Variants, motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface ChartNoAxesColumnDecreasingIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface ChartNoAxesColumnDecreasingIconProps\n  extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst lineVariants: Variants = {\n  visible: { pathLength: 1, opacity: 1 },\n  hidden: { pathLength: 0, opacity: 0 },\n};\n\nconst ChartNoAxesColumnDecreasingIcon = forwardRef<\n  ChartNoAxesColumnDecreasingIconHandle,\n  ChartNoAxesColumnDecreasingIconProps\n>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n  const controls = useAnimation();\n  const isControlledRef = useRef(false);\n\n  useImperativeHandle(ref, () => {\n    isControlledRef.current = true;\n\n    return {\n      startAnimation: async () => {\n        await controls.start((i) => ({\n          pathLength: 0,\n          opacity: 0,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n        await controls.start((i) => ({\n          pathLength: 1,\n          opacity: 1,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n      },\n      stopAnimation: () => controls.start('visible'),\n    };\n  });\n\n  const handleMouseEnter = useCallback(\n    async (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        await controls.start((i) => ({\n          pathLength: 0,\n          opacity: 0,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n        await controls.start((i) => ({\n          pathLength: 1,\n          opacity: 1,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n      } else {\n        onMouseEnter?.(e);\n      }\n    },\n    [controls, onMouseEnter]\n  );\n\n  const handleMouseLeave = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('visible');\n      } else {\n        onMouseLeave?.(e);\n      }\n    },\n    [controls, onMouseLeave]\n  );\n\n  return (\n    <div\n      className={cn(\n        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n        className\n      )}\n      onMouseEnter={handleMouseEnter}\n      onMouseLeave={handleMouseLeave}\n      {...props}\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        width={size}\n        height={size}\n        viewBox=\"0 0 24 24\"\n        fill=\"none\"\n        stroke=\"currentColor\"\n        strokeWidth=\"2\"\n        strokeLinecap=\"round\"\n        strokeLinejoin=\"round\"\n      >\n        <motion.path\n          variants={lineVariants}\n          initial=\"visible\"\n          animate={controls}\n          custom={0}\n          d=\"M6 20V4\"\n        />\n        <motion.path\n          variants={lineVariants}\n          initial=\"visible\"\n          animate={controls}\n          custom={1}\n          d=\"M12 20V10\"\n        />\n        <motion.path\n          variants={lineVariants}\n          initial=\"visible\"\n          animate={controls}\n          custom={2}\n          d=\"M18 20v-4\"\n        />\n      </svg>\n    </div>\n  );\n});\n\nChartNoAxesColumnDecreasingIcon.displayName = 'ChartNoAxesColumnDecreasingIcon';\n\nexport { ChartNoAxesColumnDecreasingIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/chart-no-axes-column-increasing.json
+++ b/public/c/chart-no-axes-column-increasing.json
@@ -1,0 +1,21 @@
+{
+  "name": "chart-no-axes-column-increasing",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "chart-no-axes-column-increasing.tsx",
+      "content": "'use client';\n\nimport { type Variants, motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface ChartNoAxesColumnIncreasingIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface ChartNoAxesColumnIncreasingIconProps\n  extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst lineVariants: Variants = {\n  visible: { pathLength: 1, opacity: 1 },\n  hidden: { pathLength: 0, opacity: 0 },\n};\n\nconst ChartNoAxesColumnIncreasingIcon = forwardRef<\n  ChartNoAxesColumnIncreasingIconHandle,\n  ChartNoAxesColumnIncreasingIconProps\n>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n  const controls = useAnimation();\n  const isControlledRef = useRef(false);\n\n  useImperativeHandle(ref, () => {\n    isControlledRef.current = true;\n\n    return {\n      startAnimation: async () => {\n        await controls.start((i) => ({\n          pathLength: 0,\n          opacity: 0,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n        await controls.start((i) => ({\n          pathLength: 1,\n          opacity: 1,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n      },\n      stopAnimation: () => controls.start('visible'),\n    };\n  });\n\n  const handleMouseEnter = useCallback(\n    async (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        await controls.start((i) => ({\n          pathLength: 0,\n          opacity: 0,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n        await controls.start((i) => ({\n          pathLength: 1,\n          opacity: 1,\n          transition: { delay: i * 0.1, duration: 0.3 },\n        }));\n      } else {\n        onMouseEnter?.(e);\n      }\n    },\n    [controls, onMouseEnter]\n  );\n\n  const handleMouseLeave = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('visible');\n      } else {\n        onMouseLeave?.(e);\n      }\n    },\n    [controls, onMouseLeave]\n  );\n\n  return (\n    <div\n      className={cn(\n        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n        className\n      )}\n      onMouseEnter={handleMouseEnter}\n      onMouseLeave={handleMouseLeave}\n      {...props}\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        width={size}\n        height={size}\n        viewBox=\"0 0 24 24\"\n        fill=\"none\"\n        stroke=\"currentColor\"\n        strokeWidth=\"2\"\n        strokeLinecap=\"round\"\n        strokeLinejoin=\"round\"\n      >\n        <motion.path\n          variants={lineVariants}\n          initial=\"visible\"\n          animate={controls}\n          custom={0}\n          d=\"M6 20v-4\"\n        />\n        <motion.path\n          variants={lineVariants}\n          initial=\"visible\"\n          animate={controls}\n          custom={1}\n          d=\"M12 20v-10\"\n        />\n        <motion.path\n          variants={lineVariants}\n          initial=\"visible\"\n          animate={controls}\n          custom={2}\n          d=\"M18 20v-16\"\n        />\n      </svg>\n    </div>\n  );\n});\n\nChartNoAxesColumnIncreasingIcon.displayName = 'ChartNoAxesColumnIncreasingIcon';\n\nexport { ChartNoAxesColumnIncreasingIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/chart-spline.json
+++ b/public/c/chart-spline.json
@@ -1,0 +1,21 @@
+{
+  "name": "chart-spline",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "chart-spline.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface ChartSplineIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface ChartSplineIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst variants: Variants = {\n  normal: {\n    pathLength: 1,\n    opacity: 1,\n  },\n  animate: {\n    pathLength: [0, 1],\n    opacity: [0, 1],\n    transition: {\n      delay: 0.15,\n      duration: 0.3,\n      opacity: { delay: 0.1 },\n    },\n  },\n};\n\nconst ChartSplineIcon = forwardRef<ChartSplineIconHandle, ChartSplineIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <path d=\"M3 3v16a2 2 0 0 0 2 2h16\" />\n          <motion.path\n            d=\"M7 16c.5-2 1.5-7 4-7 2 0 2 3 4 3 2.5 0 4.5-5 5-7\"\n            variants={variants}\n            animate={controls}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nChartSplineIcon.displayName = 'ChartSplineIcon';\n\nexport { ChartSplineIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/file-chart-line.json
+++ b/public/c/file-chart-line.json
@@ -1,0 +1,21 @@
+{
+  "name": "file-chart-line",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "file-chart-line.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface FileChartLineIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface FileChartLineIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst variants: Variants = {\n  normal: {\n    pathLength: 1,\n    opacity: 1,\n  },\n  animate: {\n    pathLength: [0, 1],\n    opacity: [0, 1],\n    transition: {\n      delay: 0.15,\n      duration: 0.3,\n      opacity: { delay: 0.1 },\n    },\n  },\n};\n\nconst FileChartLineIcon = forwardRef<\n  FileChartLineIconHandle,\n  FileChartLineIconProps\n>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n  const controls = useAnimation();\n  const isControlledRef = useRef(false);\n\n  useImperativeHandle(ref, () => {\n    isControlledRef.current = true;\n\n    return {\n      startAnimation: () => controls.start('animate'),\n      stopAnimation: () => controls.start('normal'),\n    };\n  });\n\n  const handleMouseEnter = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('animate');\n      } else {\n        onMouseEnter?.(e);\n      }\n    },\n    [controls, onMouseEnter]\n  );\n\n  const handleMouseLeave = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('normal');\n      } else {\n        onMouseLeave?.(e);\n      }\n    },\n    [controls, onMouseLeave]\n  );\n\n  return (\n    <div\n      className={cn(\n        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n        className\n      )}\n      onMouseEnter={handleMouseEnter}\n      onMouseLeave={handleMouseLeave}\n      {...props}\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        width={size}\n        height={size}\n        viewBox=\"0 0 24 24\"\n        fill=\"none\"\n        stroke=\"currentColor\"\n        strokeWidth=\"2\"\n        strokeLinecap=\"round\"\n        strokeLinejoin=\"round\"\n      >\n        <path d=\"M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z\" />\n        <path d=\"M14 2v4a2 2 0 0 0 2 2h4\" />\n        <motion.path\n          d=\"m8 17 2.5-2.5 2 2L16 13\"\n          variants={variants}\n          animate={controls}\n        />\n      </svg>\n    </div>\n  );\n});\n\nFileChartLineIcon.displayName = 'FileChartLineIcon';\n\nexport { FileChartLineIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1066,4 +1066,34 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'chart-line',
+    'path': path.join(__dirname, '../icons/chart-line.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'chart-no-axes-column-decreasing',
+    'path': path.join(__dirname, '../icons/chart-no-axes-column-decreasing.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'chart-no-axes-column-increasing',
+    'path': path.join(__dirname, '../icons/chart-no-axes-column-increasing.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'chart-spline',
+    'path': path.join(__dirname, '../icons/chart-spline.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'file-chart-line',
+    'path': path.join(__dirname, '../icons/file-chart-line.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

New feature, inclusion of 5 lucide.dev chart icons: file-chart-icon, chart-line, chart-spline, chart-no-axes-column-increasing and chart-no-axes-column decreasing

## What is the new behavior?

Demo video below of the new icons

## Demo


https://github.com/user-attachments/assets/bf840ab5-3893-4295-8463-03190db063a7


## Additional context

Basically expanded on existing icons and animation styles
