### PR TITLE
added 2 radio icons

### DIFF
--- a/icons/index.ts
+++ b/icons/index.ts
@@ -173,6 +173,8 @@ import { MessageCircleDashedIcon } from '@/icons/message-circle-dashed';
 import { MessageSquareDashedIcon } from '@/icons/message-square-dashed';
 import { FileCogIcon } from '@/icons/file-cog';
 import { CalendarDaysIcon } from '@/icons/calendar-days';
+import { RadioIcon } from './radio';
+import { RadioTowerIcon } from './radio-tower';
 
 type IconListItem = {
   name: string;
@@ -1718,6 +1720,34 @@ const ICON_LIST: IconListItem[] = [
     name: 'calendar-days',
     icon: CalendarDaysIcon,
     keywords: ['calendar', 'days', 'days of the week', 'week', 'month'],
+  },
+  {
+    name: 'radio',
+    icon: RadioIcon,
+    keywords: [
+      'radio',
+      'signal',
+      'broadcast',
+      'wireless',
+      'frequency',
+      'connectivity',
+      'live',
+    ],
+  },
+  {
+    name: 'radio-tower',
+    icon: RadioTowerIcon,
+    keywords: [
+      'radio',
+      'tower',
+      'radio tower',
+      'signal',
+      'broadcast',
+      'wireless',
+      'frequency',
+      'connectivity',
+      'live',
+    ],
   },
 ];
 

--- a/icons/radio-tower.tsx
+++ b/icons/radio-tower.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface RadioTowerIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface RadioTowerIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const variants: Variants = {
+  normal: {
+    opacity: 1,
+    transition: {
+      duration: 0.4,
+    },
+  },
+  fadeOut: {
+    opacity: 0,
+    transition: { duration: 0.3 },
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      type: 'spring',
+      stiffness: 300,
+      damping: 20,
+      delay: i * 0.1,
+    },
+  }),
+};
+
+const RadioTowerIcon = forwardRef<RadioTowerIconHandle, RadioTowerIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: async () => {
+          await controls.start('fadeOut');
+          controls.start('fadeIn');
+        },
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          await controls.start('fadeOut');
+          controls.start('fadeIn');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M4.9 16.1C1 12.2 1 5.8 4.9 1.9"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={1}
+          />
+          <motion.path
+            d="M7.8 4.7a6.14 6.14 0 0 0-.8 7.5"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={0}
+          />
+          <circle cx="12" cy="9" r="2" />
+          <motion.path
+            d="M16.2 4.8c2 2 2.26 5.11.8 7.47"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={0}
+          />
+          <motion.path
+            d="M19.1 1.9a9.96 9.96 0 0 1 0 14.1"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={1}
+          />
+          <path d="M9.5 18h5" />
+          <path d="m8 22 4-11 4 11" />
+        </svg>
+      </div>
+    );
+  }
+);
+
+RadioTowerIcon.displayName = 'RadioTowerIcon';
+
+export { RadioTowerIcon };

--- a/icons/radio.tsx
+++ b/icons/radio.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface RadioIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface RadioIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const variants: Variants = {
+  normal: {
+    opacity: 1,
+    transition: {
+      duration: 0.4,
+    },
+  },
+  fadeOut: {
+    opacity: 0,
+    transition: { duration: 0.3 },
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      type: 'spring',
+      stiffness: 300,
+      damping: 20,
+      delay: i * 0.1,
+    },
+  }),
+};
+
+const RadioIcon = forwardRef<RadioIconHandle, RadioIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: async () => {
+          await controls.start('fadeOut');
+          controls.start('fadeIn');
+        },
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          await controls.start('fadeOut');
+          controls.start('fadeIn');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={1}
+          />
+          <motion.path
+            d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={0}
+          />
+          <circle cx="12" cy="12" r="2" />
+          <motion.path
+            d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={0}
+          />
+          <motion.path
+            d="M19.1 4.9C23 8.8 23 15.1 19.1 19"
+            initial={{ opacity: 1 }}
+            variants={variants}
+            animate={controls}
+            custom={1}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+RadioIcon.displayName = 'RadioIcon';
+
+export { RadioIcon };

--- a/public/c/radio-tower.json
+++ b/public/c/radio-tower.json
@@ -1,0 +1,21 @@
+{
+  "name": "radio-tower",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "radio-tower.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface RadioTowerIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface RadioTowerIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst variants: Variants = {\n  normal: {\n    opacity: 1,\n    transition: {\n      duration: 0.4,\n    },\n  },\n  fadeOut: {\n    opacity: 0,\n    transition: { duration: 0.3 },\n  },\n  fadeIn: (i: number) => ({\n    opacity: 1,\n    transition: {\n      type: 'spring',\n      stiffness: 300,\n      damping: 20,\n      delay: i * 0.1,\n    },\n  }),\n};\n\nconst RadioTowerIcon = forwardRef<RadioTowerIconHandle, RadioTowerIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: async () => {\n          await controls.start('fadeOut');\n          controls.start('fadeIn');\n        },\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      async (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          await controls.start('fadeOut');\n          controls.start('fadeIn');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <motion.path\n            d=\"M4.9 16.1C1 12.2 1 5.8 4.9 1.9\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={1}\n          />\n          <motion.path\n            d=\"M7.8 4.7a6.14 6.14 0 0 0-.8 7.5\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={0}\n          />\n          <circle cx=\"12\" cy=\"9\" r=\"2\" />\n          <motion.path\n            d=\"M16.2 4.8c2 2 2.26 5.11.8 7.47\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={0}\n          />\n          <motion.path\n            d=\"M19.1 1.9a9.96 9.96 0 0 1 0 14.1\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={1}\n          />\n          <path d=\"M9.5 18h5\" />\n          <path d=\"m8 22 4-11 4 11\" />\n        </svg>\n      </div>\n    );\n  }\n);\n\nRadioTowerIcon.displayName = 'RadioTowerIcon';\n\nexport { RadioTowerIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/radio.json
+++ b/public/c/radio.json
@@ -1,0 +1,21 @@
+{
+  "name": "radio",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "radio.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface RadioIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface RadioIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst variants: Variants = {\n  normal: {\n    opacity: 1,\n    transition: {\n      duration: 0.4,\n    },\n  },\n  fadeOut: {\n    opacity: 0,\n    transition: { duration: 0.3 },\n  },\n  fadeIn: (i: number) => ({\n    opacity: 1,\n    transition: {\n      type: 'spring',\n      stiffness: 300,\n      damping: 20,\n      delay: i * 0.1,\n    },\n  }),\n};\n\nconst RadioIcon = forwardRef<RadioIconHandle, RadioIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: async () => {\n          await controls.start('fadeOut');\n          controls.start('fadeIn');\n        },\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      async (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          await controls.start('fadeOut');\n          controls.start('fadeIn');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <motion.path\n            d=\"M4.9 19.1C1 15.2 1 8.8 4.9 4.9\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={1}\n          />\n          <motion.path\n            d=\"M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={0}\n          />\n          <circle cx=\"12\" cy=\"12\" r=\"2\" />\n          <motion.path\n            d=\"M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={0}\n          />\n          <motion.path\n            d=\"M19.1 4.9C23 8.8 23 15.1 19.1 19\"\n            initial={{ opacity: 1 }}\n            variants={variants}\n            animate={controls}\n            custom={1}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nRadioIcon.displayName = 'RadioIcon';\n\nexport { RadioIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1066,4 +1066,16 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'radio-tower',
+    'path': path.join(__dirname, '../icons/radio-tower.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'radio',
+    'path': path.join(__dirname, '../icons/radio.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

feature: 2 new lucide.dev radio icons, the `radio` icon and the` radio-tower `icon

## What is the new behavior?

new icons for radio and connection!

## Demo

https://github.com/user-attachments/assets/0689b149-a207-4b04-905b-5361e3c14ff8

## Additional context

I think the duration is enough, let me know what you think. Also, I followed the same pattern in the `wifi` icon.
