### PR TITLE
Added 1 new boxes icon, two versions committed please choose

### DIFF
--- a/icons/boxes.tsx
+++ b/icons/boxes.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface BoxesIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface BoxesIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const BoxesIcon = forwardRef<BoxesIconHandle, BoxesIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z m4.03 3.58 -4.74 -2.85 m4.74 2.85 5-3 m-5 3v5.17"
+            variants={{
+              normal: { translateX: 0, translateY: 0 },
+              animate: { translateX: -1.5, translateY: 1.5 },
+            }}
+            animate={controls}
+          />
+          <motion.path
+            d="M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z m5 3-5-3 m5 3 4.74-2.85 M17 16.5v5.17"
+            variants={{
+              normal: { translateX: 0, translateY: 0 },
+              animate: { translateX: 1.5, translateY: 1.5 },
+            }}
+            animate={controls}
+          />
+          <motion.path
+            d="M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z M12 8 7.26 5.15 m4.74 2.85 4.74-2.85 M12 13.5V8"
+            variants={{
+              normal: { translateX: 0, translateY: 0 },
+              animate: { translateX: 0, translateY: -1.5 },
+            }}
+            animate={controls}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+BoxesIcon.displayName = 'BoxesIcon';
+
+export { BoxesIcon };

--- a/icons/boxes.tsx
+++ b/icons/boxes.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion, useAnimation } from 'motion/react';
+import { motion, useAnimation, type Variants } from 'motion/react';
 import type { HTMLAttributes } from 'react';
 import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,28 @@ export interface BoxesIconHandle {
 interface BoxesIconProps extends HTMLAttributes<HTMLDivElement> {
   size?: number;
 }
+
+const boxVariants: Variants = {
+  normal: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      type: "spring",
+      stiffness: 400,
+      damping: 25
+    }
+  },
+  animate: (i: number) => ({
+    y: [-20, 0],
+    opacity: [0, 1],
+    transition: {
+      type: "spring",
+      stiffness: 400,
+      damping: 30,
+      delay: 0.1 * (2 - i)
+    }
+  })
+};
 
 const BoxesIcon = forwardRef<BoxesIconHandle, BoxesIconProps>(
   ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
@@ -72,28 +94,25 @@ const BoxesIcon = forwardRef<BoxesIconHandle, BoxesIconProps>(
           strokeLinejoin="round"
         >
           <motion.path
-            d="M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z m4.03 3.58 -4.74 -2.85 m4.74 2.85 5-3 m-5 3v5.17"
-            variants={{
-              normal: { translateX: 0, translateY: 0 },
-              animate: { translateX: -1.5, translateY: 1.5 },
-            }}
+            d="M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z M12 8 7.26 5.15 m4.74 2.85 4.74-2.85 M12 13.5V8"
+            variants={boxVariants}
+            initial="normal"
             animate={controls}
+            custom={0}
           />
           <motion.path
             d="M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z m5 3-5-3 m5 3 4.74-2.85 M17 16.5v5.17"
-            variants={{
-              normal: { translateX: 0, translateY: 0 },
-              animate: { translateX: 1.5, translateY: 1.5 },
-            }}
+            variants={boxVariants}
+            initial="normal"
             animate={controls}
+            custom={1}
           />
           <motion.path
-            d="M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z M12 8 7.26 5.15 m4.74 2.85 4.74-2.85 M12 13.5V8"
-            variants={{
-              normal: { translateX: 0, translateY: 0 },
-              animate: { translateX: 0, translateY: -1.5 },
-            }}
+            d="M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z m4.03 3.58 -4.74 -2.85 m4.74 2.85 5-3 m-5 3v5.17"
+            variants={boxVariants}
+            initial="normal"
             animate={controls}
+            custom={2}
           />
         </svg>
       </div>

--- a/icons/boxes.tsx
+++ b/icons/boxes.tsx
@@ -19,21 +19,21 @@ const boxVariants: Variants = {
     y: 0,
     opacity: 1,
     transition: {
-      type: "spring",
+      type: 'spring',
       stiffness: 400,
-      damping: 25
-    }
+      damping: 25,
+    },
   },
   animate: (i: number) => ({
     y: [-20, 0],
     opacity: [0, 1],
     transition: {
-      type: "spring",
+      type: 'spring',
       stiffness: 400,
       damping: 30,
-      delay: 0.1 * (2 - i)
-    }
-  })
+      delay: 0.1 * (2 - i),
+    },
+  }),
 };
 
 const BoxesIcon = forwardRef<BoxesIconHandle, BoxesIconProps>(

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -180,6 +180,7 @@ import { ChartNoAxesColumnIncreasingIcon } from '@/icons/chart-no-axes-column-in
 import { ChartNoAxesColumnDecreasingIcon } from '@/icons/chart-no-axes-column-decreasing';
 import { RadioIcon } from '@/icons/radio';
 import { RadioTowerIcon } from '@/icons/radio-tower';
+import { BoxesIcon } from '@/icons/boxes';
 
 type IconListItem = {
   name: string;
@@ -1793,6 +1794,11 @@ const ICON_LIST: IconListItem[] = [
       'live',
     ],
   },
+  {
+    name: 'boxes',
+    icon: BoxesIcon,
+    keywords: ['box', 'boxes', 'cubes', 'packages', 'parts', 'group', 'units', 'collection', 'cluster', 'geometry']
+  }
 ];
 
 export { ICON_LIST };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -1797,8 +1797,19 @@ const ICON_LIST: IconListItem[] = [
   {
     name: 'boxes',
     icon: BoxesIcon,
-    keywords: ['box', 'boxes', 'cubes', 'packages', 'parts', 'group', 'units', 'collection', 'cluster', 'geometry']
-  }
+    keywords: [
+      'box',
+      'boxes',
+      'cubes',
+      'packages',
+      'parts',
+      'group',
+      'units',
+      'collection',
+      'cluster',
+      'geometry',
+    ],
+  },
 ];
 
 export { ICON_LIST };

--- a/public/c/boxes.json
+++ b/public/c/boxes.json
@@ -1,0 +1,21 @@
+{
+  "name": "boxes",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "boxes.tsx",
+      "content": "'use client';\n\nimport { motion, useAnimation, type Variants } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface BoxesIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface BoxesIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst boxVariants: Variants = {\n  normal: {\n    y: 0,\n    opacity: 1,\n    transition: {\n      type: 'spring',\n      stiffness: 400,\n      damping: 25,\n    },\n  },\n  animate: (i: number) => ({\n    y: [-20, 0],\n    opacity: [0, 1],\n    transition: {\n      type: 'spring',\n      stiffness: 400,\n      damping: 30,\n      delay: 0.1 * (2 - i),\n    },\n  }),\n};\n\nconst BoxesIcon = forwardRef<BoxesIconHandle, BoxesIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <motion.path\n            d=\"M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z M12 8 7.26 5.15 m4.74 2.85 4.74-2.85 M12 13.5V8\"\n            variants={boxVariants}\n            initial=\"normal\"\n            animate={controls}\n            custom={0}\n          />\n          <motion.path\n            d=\"M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z m5 3-5-3 m5 3 4.74-2.85 M17 16.5v5.17\"\n            variants={boxVariants}\n            initial=\"normal\"\n            animate={controls}\n            custom={1}\n          />\n          <motion.path\n            d=\"M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z m4.03 3.58 -4.74 -2.85 m4.74 2.85 5-3 m-5 3v5.17\"\n            variants={boxVariants}\n            initial=\"normal\"\n            animate={controls}\n            custom={2}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nBoxesIcon.displayName = 'BoxesIcon';\n\nexport { BoxesIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1080,13 +1080,19 @@ export const components: ComponentDefinition[] = [
   },
   {
     'name': 'chart-no-axes-column-decreasing',
-    'path': path.join(__dirname, '../icons/chart-no-axes-column-decreasing.tsx'),
+    'path': path.join(
+      __dirname,
+      '../icons/chart-no-axes-column-decreasing.tsx'
+    ),
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
   {
     'name': 'chart-no-axes-column-increasing',
-    'path': path.join(__dirname, '../icons/chart-no-axes-column-increasing.tsx'),
+    'path': path.join(
+      __dirname,
+      '../icons/chart-no-axes-column-increasing.tsx'
+    ),
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
@@ -1105,6 +1111,12 @@ export const components: ComponentDefinition[] = [
   {
     'name': 'radio',
     'path': path.join(__dirname, '../icons/radio.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'boxes',
+    'path': path.join(__dirname, '../icons/boxes.tsx'),
     'registryDependencies': [],
     'dependencies': ['motion'],
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

feature: added a new lucide.dev icon `boxes`

## What is the new behavior?

V1 boxes expand and get split in various directions on hover, V2 (latest) - Boxes drop from the top

Please choose!

## Demo

V1 (not the latest commit)

https://github.com/user-attachments/assets/c62ed891-cd88-4c39-a0d6-e4c9ff7c1c49

V2 (latest commit)

https://github.com/user-attachments/assets/e7c0f296-3cda-4023-8af9-7857ee3ef581

## Additional context

I didn't know how we were handling multiple versions so I decided to PR anyways to allow for further discussions on which one of the icon's animations is the best. Feel free to comment or suggest.
