### PR TITLE
added 2 new user check icons

### DIFF
--- a/icons/index.ts
+++ b/icons/index.ts
@@ -214,6 +214,7 @@ import { SquareChevronRightIcon } from '@/icons/square-chevron-right';
 import { SquareChevronLeftIcon } from '@/icons/square-chevron-left';
 import { GalleryHorizontalEndIcon } from '@/icons/gallery-horizontal-end';
 import { GalleryVerticalEndIcon } from '@/icons/gallery-vertical-end';
+import { UserCheckIcon } from '@/icons/user-check';
 
 type IconListItem = {
   name: string;
@@ -1783,7 +1784,7 @@ const ICON_LIST: IconListItem[] = [
   },
   {
     name: 'cctv',
-    icon: CctvIcon,
+    icon: CctvIcon,   
     keywords: [
       'cctv',
       'camera',
@@ -2116,6 +2117,11 @@ const ICON_LIST: IconListItem[] = [
       'backup',
       'time machine',
     ],
+  },
+  {
+    name: 'user-check',
+    icon: UserCheckIcon,
+    keywords: ['user', 'check', 'checkmark', 'tick', 'done', 'confirm', 'complete'],
   },
 ];
 

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -215,6 +215,7 @@ import { SquareChevronLeftIcon } from '@/icons/square-chevron-left';
 import { GalleryHorizontalEndIcon } from '@/icons/gallery-horizontal-end';
 import { GalleryVerticalEndIcon } from '@/icons/gallery-vertical-end';
 import { UserCheckIcon } from '@/icons/user-check';
+import { UserRoundCheckIcon } from '@/icons/user-round-check';
 
 type IconListItem = {
   name: string;
@@ -2121,6 +2122,11 @@ const ICON_LIST: IconListItem[] = [
   {
     name: 'user-check',
     icon: UserCheckIcon,
+    keywords: ['user', 'check', 'checkmark', 'tick', 'done', 'confirm', 'complete'],
+  },
+  {
+    name: 'user-round-check',
+    icon: UserRoundCheckIcon,
     keywords: ['user', 'check', 'checkmark', 'tick', 'done', 'confirm', 'complete'],
   },
 ];

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -1785,7 +1785,7 @@ const ICON_LIST: IconListItem[] = [
   },
   {
     name: 'cctv',
-    icon: CctvIcon,   
+    icon: CctvIcon,
     keywords: [
       'cctv',
       'camera',
@@ -2122,12 +2122,28 @@ const ICON_LIST: IconListItem[] = [
   {
     name: 'user-check',
     icon: UserCheckIcon,
-    keywords: ['user', 'check', 'checkmark', 'tick', 'done', 'confirm', 'complete'],
+    keywords: [
+      'user',
+      'check',
+      'checkmark',
+      'tick',
+      'done',
+      'confirm',
+      'complete',
+    ],
   },
   {
     name: 'user-round-check',
     icon: UserRoundCheckIcon,
-    keywords: ['user', 'check', 'checkmark', 'tick', 'done', 'confirm', 'complete'],
+    keywords: [
+      'user',
+      'check',
+      'checkmark',
+      'tick',
+      'done',
+      'confirm',
+      'complete',
+    ],
   },
 ];
 

--- a/icons/user-check.tsx
+++ b/icons/user-check.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { motion, useAnimation } from 'motion/react';
+import type { Variants } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface UserCheckIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface UserCheckIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const checkVariants: Variants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      pathLength: { duration: 0.4, ease: 'easeInOut' },
+      opacity: { duration: 0.4, ease: 'easeInOut' },
+    },
+  },
+};
+
+const UserCheckIcon = forwardRef<UserCheckIconHandle, UserCheckIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <motion.path
+            animate={controls}
+            initial="normal"
+            variants={checkVariants}
+            d="M16 11L18 13L22 9"
+            style={{ transformOrigin: 'center' }}
+          />
+        </svg>
+      </div >
+    );
+  }
+);
+
+UserCheckIcon.displayName = 'UserCheckIcon';
+
+export { UserCheckIcon };

--- a/icons/user-check.tsx
+++ b/icons/user-check.tsx
@@ -100,7 +100,7 @@ const UserCheckIcon = forwardRef<UserCheckIconHandle, UserCheckIconProps>(
             style={{ transformOrigin: 'center' }}
           />
         </svg>
-      </div >
+      </div>
     );
   }
 );

--- a/icons/user-round-check.tsx
+++ b/icons/user-round-check.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { motion, useAnimation } from 'motion/react';
+import type { Variants } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface UserRoundCheckIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface UserRoundCheckIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const checkVariants: Variants = {
+  normal: {
+    pathLength: 1,
+    opacity: 1,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  animate: {
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      pathLength: { duration: 0.4, ease: 'easeInOut' },
+      opacity: { duration: 0.4, ease: 'easeInOut' },
+    },
+  },
+};
+
+const UserRoundCheckIcon = forwardRef<UserRoundCheckIconHandle, UserRoundCheckIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M2 21a8 8 0 0 1 13.292-6" />
+          <circle cx="10" cy="8" r="5" />
+          <motion.path
+            animate={controls}
+            initial="normal"
+            variants={checkVariants}
+            d="m16 19 2 2 4-4"
+            style={{ transformOrigin: 'center' }}
+          />
+        </svg>
+      </div >
+    );
+  }
+);
+
+UserRoundCheckIcon.displayName = 'UserRoundCheckIcon';
+
+export { UserRoundCheckIcon };

--- a/icons/user-round-check.tsx
+++ b/icons/user-round-check.tsx
@@ -33,77 +33,78 @@ const checkVariants: Variants = {
   },
 };
 
-const UserRoundCheckIcon = forwardRef<UserRoundCheckIconHandle, UserRoundCheckIconProps>(
-  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
-    const controls = useAnimation();
-    const isControlledRef = useRef(false);
+const UserRoundCheckIcon = forwardRef<
+  UserRoundCheckIconHandle,
+  UserRoundCheckIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
 
-    useImperativeHandle(ref, () => {
-      isControlledRef.current = true;
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
 
-      return {
-        startAnimation: () => controls.start('animate'),
-        stopAnimation: () => controls.start('normal'),
-      };
-    });
+    return {
+      startAnimation: () => controls.start('animate'),
+      stopAnimation: () => controls.start('normal'),
+    };
+  });
 
-    const handleMouseEnter = useCallback(
-      (e: React.MouseEvent<HTMLDivElement>) => {
-        if (!isControlledRef.current) {
-          controls.start('animate');
-        } else {
-          onMouseEnter?.(e);
-        }
-      },
-      [controls, onMouseEnter]
-    );
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('animate');
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter]
+  );
 
-    const handleMouseLeave = useCallback(
-      (e: React.MouseEvent<HTMLDivElement>) => {
-        if (!isControlledRef.current) {
-          controls.start('normal');
-        } else {
-          onMouseLeave?.(e);
-        }
-      },
-      [controls, onMouseLeave]
-    );
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('normal');
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave]
+  );
 
-    return (
-      <div
-        className={cn(
-          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
-          className
-        )}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        {...props}
+  return (
+    <div
+      className={cn(
+        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+        className
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width={size}
-          height={size}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M2 21a8 8 0 0 1 13.292-6" />
-          <circle cx="10" cy="8" r="5" />
-          <motion.path
-            animate={controls}
-            initial="normal"
-            variants={checkVariants}
-            d="m16 19 2 2 4-4"
-            style={{ transformOrigin: 'center' }}
-          />
-        </svg>
-      </div >
-    );
-  }
-);
+        <path d="M2 21a8 8 0 0 1 13.292-6" />
+        <circle cx="10" cy="8" r="5" />
+        <motion.path
+          animate={controls}
+          initial="normal"
+          variants={checkVariants}
+          d="m16 19 2 2 4-4"
+          style={{ transformOrigin: 'center' }}
+        />
+      </svg>
+    </div>
+  );
+});
 
 UserRoundCheckIcon.displayName = 'UserRoundCheckIcon';
 

--- a/public/c/user-check.json
+++ b/public/c/user-check.json
@@ -1,0 +1,21 @@
+{
+  "name": "user-check",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "user-check.tsx",
+      "content": "'use client';\n\nimport { motion, useAnimation } from 'motion/react';\nimport type { Variants } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface UserCheckIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface UserCheckIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst checkVariants: Variants = {\n  normal: {\n    pathLength: 1,\n    opacity: 1,\n    transition: {\n      duration: 0.3,\n    },\n  },\n  animate: {\n    pathLength: [0, 1],\n    opacity: [0, 1],\n    transition: {\n      pathLength: { duration: 0.4, ease: 'easeInOut' },\n      opacity: { duration: 0.4, ease: 'easeInOut' },\n    },\n  },\n};\n\nconst UserCheckIcon = forwardRef<UserCheckIconHandle, UserCheckIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <path d=\"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2\" />\n          <circle cx=\"9\" cy=\"7\" r=\"4\" />\n          <motion.path\n            animate={controls}\n            initial=\"normal\"\n            variants={checkVariants}\n            d=\"M16 11L18 13L22 9\"\n            style={{ transformOrigin: 'center' }}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nUserCheckIcon.displayName = 'UserCheckIcon';\n\nexport { UserCheckIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/user-round-check.json
+++ b/public/c/user-round-check.json
@@ -1,0 +1,21 @@
+{
+  "name": "user-round-check",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "user-round-check.tsx",
+      "content": "'use client';\n\nimport { motion, useAnimation } from 'motion/react';\nimport type { Variants } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface UserRoundCheckIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface UserRoundCheckIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst checkVariants: Variants = {\n  normal: {\n    pathLength: 1,\n    opacity: 1,\n    transition: {\n      duration: 0.3,\n    },\n  },\n  animate: {\n    pathLength: [0, 1],\n    opacity: [0, 1],\n    transition: {\n      pathLength: { duration: 0.4, ease: 'easeInOut' },\n      opacity: { duration: 0.4, ease: 'easeInOut' },\n    },\n  },\n};\n\nconst UserRoundCheckIcon = forwardRef<\n  UserRoundCheckIconHandle,\n  UserRoundCheckIconProps\n>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n  const controls = useAnimation();\n  const isControlledRef = useRef(false);\n\n  useImperativeHandle(ref, () => {\n    isControlledRef.current = true;\n\n    return {\n      startAnimation: () => controls.start('animate'),\n      stopAnimation: () => controls.start('normal'),\n    };\n  });\n\n  const handleMouseEnter = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('animate');\n      } else {\n        onMouseEnter?.(e);\n      }\n    },\n    [controls, onMouseEnter]\n  );\n\n  const handleMouseLeave = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('normal');\n      } else {\n        onMouseLeave?.(e);\n      }\n    },\n    [controls, onMouseLeave]\n  );\n\n  return (\n    <div\n      className={cn(\n        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n        className\n      )}\n      onMouseEnter={handleMouseEnter}\n      onMouseLeave={handleMouseLeave}\n      {...props}\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        width={size}\n        height={size}\n        viewBox=\"0 0 24 24\"\n        fill=\"none\"\n        stroke=\"currentColor\"\n        strokeWidth=\"2\"\n        strokeLinecap=\"round\"\n        strokeLinejoin=\"round\"\n      >\n        <path d=\"M2 21a8 8 0 0 1 13.292-6\" />\n        <circle cx=\"10\" cy=\"8\" r=\"5\" />\n        <motion.path\n          animate={controls}\n          initial=\"normal\"\n          variants={checkVariants}\n          d=\"m16 19 2 2 4-4\"\n          style={{ transformOrigin: 'center' }}\n        />\n      </svg>\n    </div>\n  );\n});\n\nUserRoundCheckIcon.displayName = 'UserRoundCheckIcon';\n\nexport { UserRoundCheckIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1324,4 +1324,16 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'user-check',
+    'path': path.join(__dirname, '../icons/user-check.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'user-round-check',
+    'path': path.join(__dirname, '../icons/user-round-check.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

feat: added 2 new lucide.dev icon, `user-check` and` user-round-check`

## What is the new behavior?

They animate similarly to `shield-check` icon

## Demo

https://github.com/user-attachments/assets/042f8dfd-cee5-43b0-adfb-60756d21a88c
