### PR TITLE
added new hand-heart icon

### DIFF
--- a/icons/hand-heart.tsx
+++ b/icons/hand-heart.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface HandHeartIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface HandHeartIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+const heartVariants: Variants = {
+  normal: {
+    translateY: 0,
+    opacity: 1,
+    transition: {
+      opacity: { duration: 0.2 },
+      delay: 0.1,
+      type: 'spring',
+      stiffness: 200,
+      damping: 25,
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    translateY: [-20, 0],
+    transition: {
+      opacity: { duration: 0.2 },
+      delay: 0.1,
+      type: 'spring',
+      stiffness: 200,
+      damping: 25,
+    },
+  },
+};
+
+const HandHeartIcon = forwardRef<HandHeartIconHandle, HandHeartIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(
+          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M11 14h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 16" />
+          <path d="m7 20 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
+          <path d="m2 15 6 6" />
+          <motion.path
+            animate={controls}
+            variants={heartVariants}
+            d="M19.5 8.5c.7-.7 1.5-1.6 1.5-2.7A2.73 2.73 0 0 0 16 4a2.78 2.78 0 0 0-5 1.8c0 1.2.8 2 1.5 2.8L16 12Z"
+          />
+        </svg>
+      </div >
+    );
+  }
+);
+
+HandHeartIcon.displayName = 'HandHeartIcon';
+
+export { HandHeartIcon };

--- a/icons/hand-heart.tsx
+++ b/icons/hand-heart.tsx
@@ -105,7 +105,7 @@ const HandHeartIcon = forwardRef<HandHeartIconHandle, HandHeartIconProps>(
             d="M19.5 8.5c.7-.7 1.5-1.6 1.5-2.7A2.73 2.73 0 0 0 16 4a2.78 2.78 0 0 0-5 1.8c0 1.2.8 2 1.5 2.8L16 12Z"
           />
         </svg>
-      </div >
+      </div>
     );
   }
 );

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -214,6 +214,7 @@ import { SquareChevronRightIcon } from '@/icons/square-chevron-right';
 import { SquareChevronLeftIcon } from '@/icons/square-chevron-left';
 import { GalleryHorizontalEndIcon } from '@/icons/gallery-horizontal-end';
 import { GalleryVerticalEndIcon } from '@/icons/gallery-vertical-end';
+import { HandHeartIcon } from '@/icons/hand-heart';
 
 type IconListItem = {
   name: string;
@@ -2116,6 +2117,11 @@ const ICON_LIST: IconListItem[] = [
       'backup',
       'time machine',
     ],
+  },
+  {
+    name: 'hand-heart',
+    icon: HandHeartIcon,
+    keywords: ['hand', 'heart', 'love', 'affection', 'hug', 'cuddle', 'emotion'],
   },
 ];
 

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -2121,7 +2121,15 @@ const ICON_LIST: IconListItem[] = [
   {
     name: 'hand-heart',
     icon: HandHeartIcon,
-    keywords: ['hand', 'heart', 'love', 'affection', 'hug', 'cuddle', 'emotion'],
+    keywords: [
+      'hand',
+      'heart',
+      'love',
+      'affection',
+      'hug',
+      'cuddle',
+      'emotion',
+    ],
   },
 ];
 

--- a/public/c/hand-heart.json
+++ b/public/c/hand-heart.json
@@ -1,0 +1,21 @@
+{
+  "name": "hand-heart",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "hand-heart.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface HandHeartIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface HandHeartIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\nconst heartVariants: Variants = {\n  normal: {\n    translateY: 0,\n    opacity: 1,\n    transition: {\n      opacity: { duration: 0.2 },\n      delay: 0.1,\n      type: 'spring',\n      stiffness: 200,\n      damping: 25,\n    },\n  },\n  animate: {\n    opacity: [0, 1],\n    translateY: [-20, 0],\n    transition: {\n      opacity: { duration: 0.2 },\n      delay: 0.1,\n      type: 'spring',\n      stiffness: 200,\n      damping: 25,\n    },\n  },\n};\n\nconst HandHeartIcon = forwardRef<HandHeartIconHandle, HandHeartIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(\n          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n          className\n        )}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n          <path d=\"M11 14h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 16\" />\n          <path d=\"m7 20 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9\" />\n          <path d=\"m2 15 6 6\" />\n          <motion.path\n            animate={controls}\n            variants={heartVariants}\n            d=\"M19.5 8.5c.7-.7 1.5-1.6 1.5-2.7A2.73 2.73 0 0 0 16 4a2.78 2.78 0 0 0-5 1.8c0 1.2.8 2 1.5 2.8L16 12Z\"\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nHandHeartIcon.displayName = 'HandHeartIcon';\n\nexport { HandHeartIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1324,4 +1324,10 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'hand-heart',
+    'path': path.join(__dirname, '../icons/hand-heart.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

feature: added a new lucide.dev `hand-heart` icon

## What is the new behavior?

Inspired by the `hand-coins` icon, the heart drops to the hand.

## Demo


https://github.com/user-attachments/assets/dadab92e-a563-48e3-a543-6a57233264e1


