### PR TITLE
added a new gallery-thumbnails icon

### DIFF
--- a/icons/gallery-thumbnails.tsx
+++ b/icons/gallery-thumbnails.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface GalleryThumbnailsIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GalleryThumbnailsIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const pathVariants: Variants = {
+  normal: { opacity: 1 },
+  animate: (i: number) => ({
+    opacity: [0, 1],
+    transition: { delay: i * 0.15, duration: 0.2 },
+  }),
+};
+
+const GalleryThumbnailsIcon = forwardRef<
+  GalleryThumbnailsIconHandle,
+  GalleryThumbnailsIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+
+    return {
+      startAnimation: () => controls.start('animate'),
+      stopAnimation: () => controls.start('normal'),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('animate');
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('normal');
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn(
+        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+        className
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <rect width="18" height="14" x="3" y="3" rx="2" />
+        {[
+          "M4 21h1",
+          "M9 21h1",
+          "M14 21h1",
+          "M19 21h1",
+        ].map((d, index) => (
+          <motion.path
+            key={d}
+            d={d}
+            animate={controls}
+            variants={pathVariants}
+            custom={index + 1}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+});
+
+GalleryThumbnailsIcon.displayName = 'GalleryThumbnailsIcon';
+
+export { GalleryThumbnailsIcon };

--- a/icons/gallery-thumbnails.tsx
+++ b/icons/gallery-thumbnails.tsx
@@ -83,12 +83,7 @@ const GalleryThumbnailsIcon = forwardRef<
         strokeLinejoin="round"
       >
         <rect width="18" height="14" x="3" y="3" rx="2" />
-        {[
-          "M4 21h1",
-          "M9 21h1",
-          "M14 21h1",
-          "M19 21h1",
-        ].map((d, index) => (
+        {['M4 21h1', 'M9 21h1', 'M14 21h1', 'M19 21h1'].map((d, index) => (
           <motion.path
             key={d}
             d={d}

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -2130,8 +2130,8 @@ const ICON_LIST: IconListItem[] = [
       'album',
       'portfolio',
       'preview',
-    ]
-  }
+    ],
+  },
 ];
 
 export { ICON_LIST };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -214,6 +214,7 @@ import { SquareChevronRightIcon } from '@/icons/square-chevron-right';
 import { SquareChevronLeftIcon } from '@/icons/square-chevron-left';
 import { GalleryHorizontalEndIcon } from '@/icons/gallery-horizontal-end';
 import { GalleryVerticalEndIcon } from '@/icons/gallery-vertical-end';
+import { GalleryThumbnailsIcon } from '@/icons/gallery-thumbnails';
 
 type IconListItem = {
   name: string;
@@ -2117,6 +2118,20 @@ const ICON_LIST: IconListItem[] = [
       'time machine',
     ],
   },
+  {
+    name: 'gallery-thumbnails',
+    icon: GalleryThumbnailsIcon,
+    keywords: [
+      'gallery',
+      'thumbnails',
+      'images',
+      'carousel',
+      'pictures',
+      'album',
+      'portfolio',
+      'preview',
+    ]
+  }
 ];
 
 export { ICON_LIST };

--- a/public/c/gallery-thumbnails.json
+++ b/public/c/gallery-thumbnails.json
@@ -1,0 +1,21 @@
+{
+  "name": "gallery-thumbnails",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "gallery-thumbnails.tsx",
+      "content": "'use client';\n\nimport type { Variants } from 'motion/react';\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface GalleryThumbnailsIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface GalleryThumbnailsIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst pathVariants: Variants = {\n  normal: { opacity: 1 },\n  animate: (i: number) => ({\n    opacity: [0, 1],\n    transition: { delay: i * 0.15, duration: 0.2 },\n  }),\n};\n\nconst GalleryThumbnailsIcon = forwardRef<\n  GalleryThumbnailsIconHandle,\n  GalleryThumbnailsIconProps\n>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n  const controls = useAnimation();\n  const isControlledRef = useRef(false);\n\n  useImperativeHandle(ref, () => {\n    isControlledRef.current = true;\n\n    return {\n      startAnimation: () => controls.start('animate'),\n      stopAnimation: () => controls.start('normal'),\n    };\n  });\n\n  const handleMouseEnter = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('animate');\n      } else {\n        onMouseEnter?.(e);\n      }\n    },\n    [controls, onMouseEnter]\n  );\n\n  const handleMouseLeave = useCallback(\n    (e: React.MouseEvent<HTMLDivElement>) => {\n      if (!isControlledRef.current) {\n        controls.start('normal');\n      } else {\n        onMouseLeave?.(e);\n      }\n    },\n    [controls, onMouseLeave]\n  );\n\n  return (\n    <div\n      className={cn(\n        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,\n        className\n      )}\n      onMouseEnter={handleMouseEnter}\n      onMouseLeave={handleMouseLeave}\n      {...props}\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        width={size}\n        height={size}\n        viewBox=\"0 0 24 24\"\n        fill=\"none\"\n        stroke=\"currentColor\"\n        strokeWidth=\"2\"\n        strokeLinecap=\"round\"\n        strokeLinejoin=\"round\"\n      >\n        <rect width=\"18\" height=\"14\" x=\"3\" y=\"3\" rx=\"2\" />\n        {['M4 21h1', 'M9 21h1', 'M14 21h1', 'M19 21h1'].map((d, index) => (\n          <motion.path\n            key={d}\n            d={d}\n            animate={controls}\n            variants={pathVariants}\n            custom={index + 1}\n          />\n        ))}\n      </svg>\n    </div>\n  );\n});\n\nGalleryThumbnailsIcon.displayName = 'GalleryThumbnailsIcon';\n\nexport { GalleryThumbnailsIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1324,4 +1324,10 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'gallery-thumbnails',
+    'path': path.join(__dirname, '../icons/gallery-thumbnails.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `yarn gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

feat: added a new lucide.dev `gallery-thumbnails` icon

## What is the new behavior?

It is animated similarly to `message-circle-dashed` icon

## Demo

https://github.com/user-attachments/assets/022d0695-bdb3-40fb-b438-243697f51b8a


