### PR TITLE
feat: add new "prompt/terminal" animated icon with blinking cursor and arrow motion

### DIFF
--- a/icons/index.ts
+++ b/icons/index.ts
@@ -250,6 +250,7 @@ import { UserRoundPlusIcon } from '@/icons/user-round-plus';
 import { PanelLeftOpenIcon } from '@/icons/panel-left-open';
 import { PanelLeftCloseIcon } from '@/icons/panel-left-close';
 import { PanelRightOpenIcon } from '@/icons/panel-right-open';
+import { PromptIcon } from '@/icons/prompt';
 
 type IconListItem = {
   name: string;
@@ -2349,45 +2350,35 @@ const ICON_LIST: IconListItem[] = [
   {
     name: 'user-round-plus',
     icon: UserRoundPlusIcon,
-    keywords: [
-      'user',
-      'plus',
-      'add',
-      'create',
-      'new'
-    ],
+    keywords: ['user', 'plus', 'add', 'create', 'new'],
   },
   {
     name: 'panel-left-open',
     icon: PanelLeftOpenIcon,
-    keywords: [
-      'panel',
-      'left',
-      'open',
-      'menu',
-      'navigation'
-    ],
+    keywords: ['panel', 'left', 'open', 'menu', 'navigation'],
   },
   {
     name: 'panel-left-close',
     icon: PanelLeftCloseIcon,
-    keywords: [
-      'panel',
-      'left',
-      'close',
-      'menu',
-      'navigation'
-    ],
+    keywords: ['panel', 'left', 'close', 'menu', 'navigation'],
   },
   {
     name: 'panel-right-open',
     icon: PanelRightOpenIcon,
+    keywords: ['panel', 'right', 'open', 'menu', 'navigation'],
+  },
+  {
+    name: 'prompt',
+    icon: PromptIcon,
     keywords: [
-      'panel',
-      'right',
-      'open',
-      'menu',
-      'navigation'
+      'prompt',
+      'ai',
+      'input',
+      'query',
+      'shell',
+      'cli',
+      'code',
+      'terminal-prompt',
     ],
   },
 ];

--- a/icons/prompt.tsx
+++ b/icons/prompt.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface PromptIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PromptIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const caretVariants: Variants = {
+  normal: { opacity: 1 },
+  blink: {
+    opacity: [1, 0, 1],
+    transition: {
+      duration: 1,
+      repeat: Infinity,
+      ease: 'linear',
+    },
+  },
+};
+
+const arrowVariants: Variants = {
+  initial: { y: 0 },
+  animate: {
+    y: [0, -1.5, 0],
+    transition: {
+      duration: 1.5,
+      repeat: Infinity,
+      ease: 'easeInOut',
+    },
+  },
+};
+
+const PromptIcon = forwardRef<PromptIconHandle, PromptIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start('blink'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback((e: any) => {
+      if (!isControlledRef.current) controls.start('blink');
+      else onMouseEnter?.(e);
+    }, []);
+
+    const handleMouseLeave = useCallback((e: any) => {
+      if (!isControlledRef.current) controls.start('normal');
+      else onMouseLeave?.(e);
+    }, []);
+
+    return (
+      <div
+        className={cn(
+          'cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center',
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.polyline
+            points="4 17 10 11 4 5"
+            variants={arrowVariants}
+            initial="initial"
+            animate="animate"
+          />
+          <motion.line
+            x1="12"
+            x2="20"
+            y1="19"
+            y2="19"
+            variants={caretVariants}
+            animate={controls}
+            initial="normal"
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+PromptIcon.displayName = 'PromptIcon';
+export { PromptIcon };

--- a/icons/user-round-plus.tsx
+++ b/icons/user-round-plus.tsx
@@ -45,83 +45,84 @@ const horizontalBarVariants: Variants = {
   },
 };
 
-const UserRoundPlusIcon = forwardRef<UserRoundPlusIconHandle, UserRoundPlusIconProps>(
-  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
-    const controls = useAnimation();
-    const isControlledRef = useRef(false);
+const UserRoundPlusIcon = forwardRef<
+  UserRoundPlusIconHandle,
+  UserRoundPlusIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
 
-    useImperativeHandle(ref, () => {
-      isControlledRef.current = true;
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
 
-      return {
-        startAnimation: () => controls.start('animate'),
-        stopAnimation: () => controls.start('normal'),
-      };
-    });
+    return {
+      startAnimation: () => controls.start('animate'),
+      stopAnimation: () => controls.start('normal'),
+    };
+  });
 
-    const handleMouseEnter = useCallback(
-      (e: React.MouseEvent<HTMLDivElement>) => {
-        if (!isControlledRef.current) {
-          controls.start('animate');
-        } else {
-          onMouseEnter?.(e);
-        }
-      },
-      [controls, onMouseEnter]
-    );
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('animate');
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter]
+  );
 
-    const handleMouseLeave = useCallback(
-      (e: React.MouseEvent<HTMLDivElement>) => {
-        if (!isControlledRef.current) {
-          controls.start('normal');
-        } else {
-          onMouseLeave?.(e);
-        }
-      },
-      [controls, onMouseLeave]
-    );
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start('normal');
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave]
+  );
 
-    return (
-      <div
-        className={cn(
-          `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
-          className
-        )}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        {...props}
+  return (
+    <div
+      className={cn(
+        `cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center`,
+        className
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        initial="normal"
       >
-        <motion.svg
-          xmlns="http://www.w3.org/2000/svg"
-          width={size}
-          height={size}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+        <path d="M2 21a8 8 0 0 1 13.292-6" />
+        <circle cx="10" cy="8" r="5" />
+        <motion.path
+          d="M19 16v6"
+          variants={verticalBarVariants}
           initial="normal"
-        >
-          <path d="M2 21a8 8 0 0 1 13.292-6" />
-          <circle cx="10" cy="8" r="5" />
-          <motion.path
-            d="M19 16v6"
-            variants={verticalBarVariants}
-            initial="normal"
-            animate={controls}
-          />
-          <motion.path
-            d="M22 19h-6"
-            variants={horizontalBarVariants}
-            initial="normal"
-            animate={controls}
-          />
-        </motion.svg>
-      </div>
-    );
-  }
-);
+          animate={controls}
+        />
+        <motion.path
+          d="M22 19h-6"
+          variants={horizontalBarVariants}
+          initial="normal"
+          animate={controls}
+        />
+      </motion.svg>
+    </div>
+  );
+});
 
 UserRoundPlusIcon.displayName = 'UserRoundPlusIcon';
 

--- a/public/c/prompt.json
+++ b/public/c/prompt.json
@@ -1,0 +1,19 @@
+{
+  "name": "prompt",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": ["motion"],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "prompt.tsx",
+      "content": "",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1553,5 +1553,11 @@ export const components: ComponentDefinition[] = [
     'path': path.join(__dirname, '../icons/user-round-plus.tsx'),
     'registryDependencies': [],
     'dependencies': ['motion'],
-  }
+  },
+  {
+    name: 'prompt',
+    path: path.join(__dirname, '../icons/prompt.tsx'),
+    registryDependencies: [],
+    dependencies: ['motion'],
+  },
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

**YES**

## I have run `yarn gen-cli` to generate the necessary files

**YES**

## What kind of change does this PR introduce?

- ✨ New animated icon: `prompt`

## What is the new behavior?

This PR adds a new animated icon named `prompt`, featuring:
- A blinking horizontal caret line (like a terminal cursor)
- An animated left arrow that gently moves to indicate command-line interaction
- Designed to visually represent shell/CLI prompts or terminal-style input

## Demo


https://github.com/user-attachments/assets/1b6135d7-2ff1-4ca5-bd97-9e2827e7508a



## Additional context

This icon helps cover use cases where users want to indicate input, command prompts, or code terminal concepts — which were previously only implied by `terminal`.

---
