### PR TITLE
Add crown animated icon

### DIFF
--- a/icons/crown.tsx
+++ b/icons/crown.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { motion, useAnimation } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface CrownIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface CrownIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CrownIcon = forwardRef<CrownIconHandle, CrownIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          variants={{
+            normal: { y: 0 },
+            animate: { y: [0, -3, 0] },
+          }}
+          transition={{
+            duration: 0.6,
+            ease: [0.4, 0, 0.2, 1],
+          }}
+        >
+          <motion.path
+            d="M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 5.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.734H5.81a1 1 0 0 1-.957-.734L2.02 6.02a.5.5 0 0 1 .798-.519l4.276 3.664a1 1 0 0 0 1.516-.294z"
+            variants={{
+              normal: { pathLength: 1, opacity: 1 },
+              animate: { pathLength: [0, 1], opacity: [0, 1] },
+            }}
+            transition={{
+              duration: 0.8,
+              ease: 'easeOut',
+            }}
+          />
+          <motion.path
+            d="M5 21h14"
+            variants={{
+              normal: { pathLength: 1 },
+              animate: { pathLength: [0, 1] },
+            }}
+            transition={{
+              delay: 0.3,
+              duration: 0.4,
+            }}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+CrownIcon.displayName = 'CrownIcon';
+
+export { CrownIcon };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -1,3 +1,4 @@
+import { CrownIcon } from '@/icons/crown';
 import { AlarmClockIcon } from '@/icons/alarm-clock';
 import { AlignCenterIcon } from '@/icons/align-center';
 import { AlignHorizontalIcon } from '@/icons/align-horizontal';
@@ -269,6 +270,20 @@ type IconListItem = {
 };
 
 const ICON_LIST: IconListItem[] = [
+  {
+    name: 'crown',
+    icon: CrownIcon,
+    keywords: [
+      'diadem',
+      'tiara',
+      'circlet',
+      'corona',
+      'king',
+      'ruler',
+      'winner',
+      'favourite',
+    ],
+  },
   {
     name: 'lock-keyhole-open',
     icon: LockKeyholeOpenIcon,

--- a/public/c/crown.json
+++ b/public/c/crown.json
@@ -1,0 +1,21 @@
+{
+  "name": "crown",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "files": [
+    {
+      "path": "crown.tsx",
+      "content": "'use client';\n\nimport { motion, useAnimation } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { cn } from '@/lib/utils';\n\nexport interface CrownIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface CrownIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst CrownIcon = forwardRef<CrownIconHandle, CrownIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(className)}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <motion.svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n          animate={controls}\n          variants={{\n            normal: { y: 0 },\n            animate: { y: [0, -3, 0] },\n          }}\n          transition={{\n            duration: 0.6,\n            ease: [0.4, 0, 0.2, 1],\n          }}\n        >\n          <motion.path\n            d=\"M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 5.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.734H5.81a1 1 0 0 1-.957-.734L2.02 6.02a.5.5 0 0 1 .798-.519l4.276 3.664a1 1 0 0 0 1.516-.294z\"\n            variants={{\n              normal: { pathLength: 1, opacity: 1 },\n              animate: { pathLength: [0, 1], opacity: [0, 1] },\n            }}\n            transition={{\n              duration: 0.8,\n              ease: 'easeOut',\n            }}\n          />\n          <motion.path\n            d=\"M5 21h14\"\n            variants={{\n              normal: { pathLength: 1 },\n              animate: { pathLength: [0, 1] },\n            }}\n            transition={{\n              delay: 0.3,\n              duration: 0.4,\n            }}\n          />\n        </motion.svg>\n      </div>\n    );\n  }\n);\n\nCrownIcon.displayName = 'CrownIcon';\n\nexport { CrownIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -1620,4 +1620,10 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'crown',
+    'path': path.join(__dirname, '../icons/crown.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  }
 ];


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## I have run `pnpm gen-cli` to generate the necessary files

YES

## What kind of change does this PR introduce?

Added crown animated icon

## What is the new behavior?

1. crown lifts up during animation
2. the bottom line draw from left side to right side
3. the crown draw from right side to left side

## Demo

[Link to short loom demo](https://www.loom.com/share/964f20cd6a70406d8a5808b5429d4258?sid=8103c026-395a-4939-b7b7-ee3d435eb525)

## Additional context

N/A
