### PR TITLE
Add scrollbar-gutter to avoid layout shift

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -167,6 +167,10 @@
     );
   }
 
+  html {
+    scrollbar-gutter: stable;
+  }
+
   ::selection {
     background-color: hsl(var(--accent));
     color: hsl(var(--foreground));


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Prevent layout shifts when toggling between scrollable and non-scrollable content.

## Demo


https://github.com/user-attachments/assets/89aef580-e39f-4c22-a813-9519ec89e923

