### PR TITLE
added align-left and align-right animated icons

### DIFF
--- a/icons/align-left.tsx
+++ b/icons/align-left.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import type { Transition } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { motion, useAnimation } from 'motion/react';
+
+import { cn } from '@/lib/utils';
+
+export interface AlignLeftIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AlignLeftIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  type: 'spring',
+  stiffness: 150,
+  damping: 15,
+  mass: 0.3,
+};
+
+const AlignLeftIcon = forwardRef<AlignLeftIconHandle, AlignLeftIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+         
+          <motion.line
+            x1="3"
+            x2="21"
+            y1="6"
+            y2="6"
+            variants={{
+              normal: { x2: 21 },
+              animate: { x2: 21 },
+            }}
+            animate={controls}
+            transition={DEFAULT_TRANSITION}
+          />
+         
+          <motion.line
+            x1="3"
+            x2="15"
+            y1="12"
+            y2="12"
+            variants={{
+              normal: { x2: 15 },
+              animate: { x2: 19 },
+            }}
+            animate={controls}
+            transition={DEFAULT_TRANSITION}
+          />
+         
+          <motion.line
+            x1="3"
+            x2="17"
+            y1="18"
+            y2="18"
+            variants={{
+              normal: { x2: 17 },
+              animate: { x2: 12 },
+            }}
+            animate={controls}
+            transition={DEFAULT_TRANSITION}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+AlignLeftIcon.displayName = 'AlignLeftIcon';
+
+export { AlignLeftIcon };

--- a/icons/align-right.tsx
+++ b/icons/align-right.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import type { Transition } from 'motion/react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import { motion, useAnimation } from 'motion/react';
+
+import { cn } from '@/lib/utils';
+
+export interface AlignRightIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AlignRightIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  type: 'spring',
+  stiffness: 150,
+  damping: 15,
+  mass: 0.3,
+};
+
+const AlignRightIcon = forwardRef<AlignRightIconHandle, AlignRightIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start('animate'),
+        stopAnimation: () => controls.start('normal'),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('animate');
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start('normal');
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+         
+          <motion.line
+            x1="3"
+            x2="21"
+            y1="6"
+            y2="6"
+            variants={{
+              normal: { x1: 3 },
+              animate: { x1: 3 },
+            }}
+            animate={controls}
+            transition={DEFAULT_TRANSITION}
+          />
+         
+          <motion.line
+            x1="9"
+            x2="21"
+            y1="12"
+            y2="12"
+            variants={{
+              normal: { x1: 9 },
+              animate: { x1: 5 },
+            }}
+            animate={controls}
+            transition={DEFAULT_TRANSITION}
+          />
+         
+          <motion.line
+            x1="7"
+            x2="21"
+            y1="18"
+            y2="18"
+            variants={{
+              normal: { x1: 7 },
+              animate: { x1: 12 },
+            }}
+            animate={controls}
+            transition={DEFAULT_TRANSITION}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+AlignRightIcon.displayName = 'AlignRightIcon';
+
+export { AlignRightIcon };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -8,6 +8,8 @@ import { AirplayIcon } from '@/icons/airplay';
 import { AlarmClockIcon } from '@/icons/alarm-clock';
 import { AlignCenterIcon } from '@/icons/align-center';
 import { AlignHorizontalIcon } from '@/icons/align-horizontal';
+import { AlignLeftIcon } from '@/icons/align-left';
+import { AlignRightIcon } from '@/icons/align-right';
 import { AlignVerticalIcon } from '@/icons/align-vertical';
 import { AngryIcon } from '@/icons/angry';
 import { AnnoyedIcon } from '@/icons/annoyed';
@@ -365,6 +367,16 @@ type IconListItem = {
 };
 
 const ICON_LIST: IconListItem[] = [
+  {
+    name: 'align-left',
+    icon: AlignLeftIcon,
+    keywords: ['text', 'alignment', 'left', 'paragraph', 'format'],
+  },
+  {
+    name: 'align-right',
+    icon: AlignRightIcon,
+    keywords: ['text', 'alignment', 'right', 'paragraph', 'format'],
+  },
   {
     name: 'folder-lock',
     icon: FolderLockIcon,

--- a/public/r/align-left.json
+++ b/public/r/align-left.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "align-left",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "files": [
+    {
+      "path": "align-left.tsx",
+      "content": "'use client';\n\nimport type { Transition } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { motion, useAnimation } from 'motion/react';\n\nimport { cn } from '@/lib/utils';\n\nexport interface AlignLeftIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface AlignLeftIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst DEFAULT_TRANSITION: Transition = {\n  type: 'spring',\n  stiffness: 150,\n  damping: 15,\n  mass: 0.3,\n};\n\nconst AlignLeftIcon = forwardRef<AlignLeftIconHandle, AlignLeftIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(className)}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n         \n          <motion.line\n            x1=\"3\"\n            x2=\"21\"\n            y1=\"6\"\n            y2=\"6\"\n            variants={{\n              normal: { x2: 21 },\n              animate: { x2: 21 },\n            }}\n            animate={controls}\n            transition={DEFAULT_TRANSITION}\n          />\n         \n          <motion.line\n            x1=\"3\"\n            x2=\"15\"\n            y1=\"12\"\n            y2=\"12\"\n            variants={{\n              normal: { x2: 15 },\n              animate: { x2: 19 },\n            }}\n            animate={controls}\n            transition={DEFAULT_TRANSITION}\n          />\n         \n          <motion.line\n            x1=\"3\"\n            x2=\"17\"\n            y1=\"18\"\n            y2=\"18\"\n            variants={{\n              normal: { x2: 17 },\n              animate: { x2: 12 },\n            }}\n            animate={controls}\n            transition={DEFAULT_TRANSITION}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nAlignLeftIcon.displayName = 'AlignLeftIcon';\n\nexport { AlignLeftIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/r/align-right.json
+++ b/public/r/align-right.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "align-right",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "motion"
+  ],
+  "devDependencies": [],
+  "files": [
+    {
+      "path": "align-right.tsx",
+      "content": "'use client';\n\nimport type { Transition } from 'motion/react';\nimport type { HTMLAttributes } from 'react';\nimport { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';\nimport { motion, useAnimation } from 'motion/react';\n\nimport { cn } from '@/lib/utils';\n\nexport interface AlignRightIconHandle {\n  startAnimation: () => void;\n  stopAnimation: () => void;\n}\n\ninterface AlignRightIconProps extends HTMLAttributes<HTMLDivElement> {\n  size?: number;\n}\n\nconst DEFAULT_TRANSITION: Transition = {\n  type: 'spring',\n  stiffness: 150,\n  damping: 15,\n  mass: 0.3,\n};\n\nconst AlignRightIcon = forwardRef<AlignRightIconHandle, AlignRightIconProps>(\n  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {\n    const controls = useAnimation();\n    const isControlledRef = useRef(false);\n\n    useImperativeHandle(ref, () => {\n      isControlledRef.current = true;\n\n      return {\n        startAnimation: () => controls.start('animate'),\n        stopAnimation: () => controls.start('normal'),\n      };\n    });\n\n    const handleMouseEnter = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('animate');\n        } else {\n          onMouseEnter?.(e);\n        }\n      },\n      [controls, onMouseEnter]\n    );\n\n    const handleMouseLeave = useCallback(\n      (e: React.MouseEvent<HTMLDivElement>) => {\n        if (!isControlledRef.current) {\n          controls.start('normal');\n        } else {\n          onMouseLeave?.(e);\n        }\n      },\n      [controls, onMouseLeave]\n    );\n\n    return (\n      <div\n        className={cn(className)}\n        onMouseEnter={handleMouseEnter}\n        onMouseLeave={handleMouseLeave}\n        {...props}\n      >\n        <svg\n          xmlns=\"http://www.w3.org/2000/svg\"\n          width={size}\n          height={size}\n          viewBox=\"0 0 24 24\"\n          fill=\"none\"\n          stroke=\"currentColor\"\n          strokeWidth=\"2\"\n          strokeLinecap=\"round\"\n          strokeLinejoin=\"round\"\n        >\n         \n          <motion.line\n            x1=\"3\"\n            x2=\"21\"\n            y1=\"6\"\n            y2=\"6\"\n            variants={{\n              normal: { x1: 3 },\n              animate: { x1: 3 },\n            }}\n            animate={controls}\n            transition={DEFAULT_TRANSITION}\n          />\n         \n          <motion.line\n            x1=\"9\"\n            x2=\"21\"\n            y1=\"12\"\n            y2=\"12\"\n            variants={{\n              normal: { x1: 9 },\n              animate: { x1: 5 },\n            }}\n            animate={controls}\n            transition={DEFAULT_TRANSITION}\n          />\n         \n          <motion.line\n            x1=\"7\"\n            x2=\"21\"\n            y1=\"18\"\n            y2=\"18\"\n            variants={{\n              normal: { x1: 7 },\n              animate: { x1: 12 },\n            }}\n            animate={controls}\n            transition={DEFAULT_TRANSITION}\n          />\n        </svg>\n      </div>\n    );\n  }\n);\n\nAlignRightIcon.displayName = 'AlignRightIcon';\n\nexport { AlignRightIcon };\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -4669,6 +4669,32 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "align-left",
+      "type": "registry:ui",
+      "registryDependencies": [],
+      "dependencies": ["motion"],
+      "devDependencies": [],
+      "files": [
+        {
+          "path": "align-left.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "align-right",
+      "type": "registry:ui",
+      "registryDependencies": [],
+      "dependencies": ["motion"],
+      "devDependencies": [],
+      "files": [
+        {
+          "path": "align-right.tsx",
+          "type": "registry:ui"
+        }
+      ]
     }
   ]
 }

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -2185,4 +2185,16 @@ export const components: ComponentDefinition[] = [
     'registryDependencies': [],
     'dependencies': ['motion'],
   },
+  {
+    'name': 'align-left',
+    'path': path.join(__dirname, '../icons/align-left.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
+  {
+    'name': 'align-right',
+    'path': path.join(__dirname, '../icons/align-right.tsx'),
+    'registryDependencies': [],
+    'dependencies': ['motion'],
+  },
 ];


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR adds animated icons for `align-left` (text-align-start) and `align-right` (text-align-end), completing the text alignment icon set alongside the existing `align-center`.

**Closes #190**

## Demo

https://github.com/user-attachments/assets/24c11983-3842-4d2b-acdd-3426b8fba055


https://github.com/user-attachments/assets/9f51124e-ef89-49b1-b20e-4633d0cc29ff



