### PR TITLE
feat: add category filter and icon customizer

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useOpenPanel } from "@openpanel/nextjs";
-import { Copy, PauseIcon, PlayIcon, Terminal } from "lucide-react";
+import { Copy, PauseIcon, PlayIcon, Terminal, Settings } from "lucide-react";
 import type { RefObject } from "react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -299,9 +299,10 @@ const OpenInV0Action = ({ name }: Pick<Icon, "name">) => {
 
 type ActionsProps = Pick<Icon, "name"> & {
   alwaysVisible?: boolean;
+  onCustomizeClick?: () => void;
 };
 
-const Actions = ({ name, alwaysVisible = false }: ActionsProps) => {
+const Actions = ({ name, alwaysVisible = false, onCustomizeClick }: ActionsProps) => {
   return (
     <TooltipProvider>
       <div
@@ -312,6 +313,22 @@ const Actions = ({ name, alwaysVisible = false }: ActionsProps) => {
             : "opacity-0 group-hover/card:opacity-100 has-data-busy:opacity-100 has-data-popup-open:opacity-100 has-focus-visible:opacity-100 [@media(hover:none)]:opacity-100"
         )}
       >
+        {onCustomizeClick && (
+          <Tooltip>
+            <TooltipTrigger
+              aria-label="Customize icon"
+              className="supports-[corner-shape:squircle]:corner-squircle flex size-10 cursor-pointer items-center justify-center rounded-[14px] bg-neutral-200/20 transition-[background-color] duration-100 focus-within:-outline-offset-1 hover:bg-neutral-200 focus-visible:outline-1 focus-visible:outline-primary supports-[corner-shape:squircle]:rounded-[20px] dark:bg-neutral-800/20 dark:hover:bg-neutral-700"
+              onClick={onCustomizeClick}
+              tabIndex={0}
+            >
+              <Settings
+                aria-hidden="true"
+                className="size-4 text-neutral-800 dark:text-neutral-100"
+              />
+            </TooltipTrigger>
+            <TooltipContent>Customize icon</TooltipContent>
+          </Tooltip>
+        )}
         <CopyCodeAction name={name} />
         <CopyCLIAction name={name} />
         <OpenInV0Action name={name} />

--- a/components/category-filter.tsx
+++ b/components/category-filter.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { motion } from "motion/react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { cn } from "@/lib/utils";
+
+export type Category = {
+  id: string;
+  label: string;
+  keywords: string[];
+};
+
+export const CATEGORIES: Category[] = [
+  { id: "all", label: "All", keywords: [] },
+  { id: "ui", label: "UI", keywords: ["button", "input", "menu", "panel", "layout", "grid", "list", "card", "modal", "dialog", "dropdown", "select", "checkbox", "radio", "toggle", "switch", "slider", "progress", "badge", "chip", "avatar", "tooltip", "popover"] },
+  { id: "arrows", label: "Arrows", keywords: ["arrow", "chevron", "corner", "trending"] },
+  { id: "files", label: "Files", keywords: ["file", "folder", "document"] },
+  { id: "social", label: "Social", keywords: ["github", "twitter", "facebook", "instagram", "linkedin", "youtube", "discord", "twitch", "dribbble", "figma", "gitlab"] },
+  { id: "communication", label: "Communication", keywords: ["mail", "message", "chat", "phone", "bell", "notification"] },
+  { id: "media", label: "Media", keywords: ["play", "pause", "volume", "music", "video", "image", "camera", "mic"] },
+  { id: "weather", label: "Weather", keywords: ["sun", "moon", "cloud", "rain", "snow", "wind", "storm"] },
+  { id: "symbols", label: "Symbols", keywords: ["check", "plus", "minus", "x", "circle", "square", "star", "heart", "bookmark", "flag"] },
+];
+
+type CategoryFilterProps = {
+  selectedCategory: string;
+  onCategoryChange: (category: string) => void;
+  categoryOpen: boolean;
+  setCategoryOpen: (open: boolean) => void;
+};
+
+export const CategoryFilter = ({
+  selectedCategory,
+  onCategoryChange,
+  categoryOpen,
+  setCategoryOpen,
+}: CategoryFilterProps) => {
+  useHotkeys(
+    "mod+C",
+    () => {
+      setCategoryOpen(!categoryOpen);
+    },
+    {
+      preventDefault: true,
+      enabled: true,
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+    }
+  );
+
+  useHotkeys(
+    "escape",
+    () => {
+      setCategoryOpen(false);
+    },
+    {
+      preventDefault: true,
+      enabled: categoryOpen,
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+    }
+  );
+
+  const handleCategorySelect = (categoryId: string) => {
+    onCategoryChange(categoryId);
+    setCategoryOpen(false);
+  };
+
+  return (
+    <>
+      <div className="hidden items-center justify-start gap-1 md:flex">
+        {!categoryOpen ? (
+          <>
+            <div className="flex items-center justify-center gap-0.5">
+              <kbd>⌘</kbd>
+              <kbd>C</kbd>
+            </div>
+            <span className="font-sans text-neutral-500 text-sm dark:text-neutral-500">
+              for categories
+            </span>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center justify-center gap-0.5">
+              <kbd>⌘</kbd>
+              <kbd>C</kbd>
+            </div>
+            <span className="font-sans text-neutral-500 text-sm dark:text-neutral-500">
+              to close
+            </span>
+          </>
+        )}
+      </div>
+
+      {categoryOpen && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-8 bg-background/80 backdrop-blur-sm">
+          <div className="flex flex-wrap items-center justify-center gap-2 max-w-[600px] px-4">
+            {CATEGORIES.map((category, index) => (
+              <motion.button
+                key={category.id}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: index * 0.03, duration: 0.2, ease: "easeOut" }}
+                onClick={() => handleCategorySelect(category.id)}
+                className={cn(
+                  "supports-[corner-shape:squircle]:corner-squircle inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-[12px] px-5 py-2.5 font-sans text-[15px] font-medium transition-all duration-150 supports-[corner-shape:squircle]:rounded-[18px]",
+                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                  selectedCategory === category.id
+                    ? "bg-primary text-white shadow-lg scale-105"
+                    : "bg-white text-foreground ring-1 ring-neutral-200 hover:scale-105 hover:shadow-md dark:bg-neutral-900 dark:ring-neutral-800"
+                )}
+                type="button"
+              >
+                {category.label}
+              </motion.button>
+            ))}
+          </div>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2, duration: 0.3 }}
+            className="flex items-center gap-2 text-neutral-400 dark:text-neutral-500"
+          >
+            <span className="font-sans text-sm"><span className="font-semibold">esc</span> to exit</span>
+          </motion.div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -128,8 +128,8 @@ const Header = () => {
           tabIndex={0}
         >
           <Logo
-            className="w-6 text-primary data-[type='christmas']:translate-y-[-4px] min-[395px]:w-8"
-            type="christmas"
+            className="w-6 text-primary min-[395px]:w-8"
+            type="default"
           />
           lucide-animated
         </Link>

--- a/components/icon-customizer-modal.tsx
+++ b/components/icon-customizer-modal.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { motion, AnimatePresence } from "motion/react";
+import { useEffect, useState, useCallback } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { Copy, RotateCcw, Shuffle, Maximize2 } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { getIconContent } from "@/actions/get-icon-content";
+
+type CustomizerSettings = {
+  color: string;
+  size: number;
+  darkBg: boolean;
+};
+
+const DEFAULT_SETTINGS: CustomizerSettings = {
+  color: "#FFFFFF",
+  size: 64,
+  darkBg: true,
+};
+
+const PRESET_COLORS = [
+  "#FFFFFF", "#000000", "#FF6B6B", "#4ECDC4", 
+  "#45B7D1", "#FFA07A", "#98D8C8", "#F7DC6F"
+];
+
+type IconCustomizerModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  iconName: string;
+  IconComponent: React.ElementType;
+};
+
+export const IconCustomizerModal = ({
+  isOpen,
+  onClose,
+  iconName,
+  IconComponent,
+}: IconCustomizerModalProps) => {
+  const [settings, setSettings] = useState<CustomizerSettings>(DEFAULT_SETTINGS);
+
+  const handleReset = useCallback(() => {
+    setSettings(DEFAULT_SETTINGS);
+    toast.success("Reset to defaults");
+  }, []);
+
+  const handleRandomize = useCallback(() => {
+    setSettings((prev) => ({
+      ...prev,
+      color: PRESET_COLORS[Math.floor(Math.random() * PRESET_COLORS.length)],
+    }));
+  }, []);
+
+  const handleCopyCustomCode = useCallback(async () => {
+    try {
+      let fullCode = await getIconContent(iconName);
+      
+      // Replace default size with custom size
+      if (settings.size !== 28) {
+        fullCode = fullCode.replace(/size = 28/g, `size = ${settings.size}`);
+      }
+      
+      // Replace currentColor with custom color if not white
+      if (settings.color !== "#FFFFFF") {
+        fullCode = fullCode.replace(/stroke="currentColor"/g, `stroke="${settings.color}"`);
+      }
+      
+      await navigator.clipboard.writeText(fullCode);
+      toast.success("Customized icon code copied");
+    } catch {
+      toast.error("Failed to copy code");
+    }
+  }, [iconName, settings.size, settings.color]);
+
+  useHotkeys("escape", onClose, { enabled: isOpen });
+  useHotkeys("r", handleReset, { enabled: isOpen, preventDefault: true });
+  useHotkeys("c", handleCopyCustomCode, { enabled: isOpen, preventDefault: true });
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  const handleColorChange = useCallback((color: string) => {
+    setSettings((prev) => ({ ...prev, color }));
+  }, []);
+
+  const handleSizeChange = useCallback((size: number) => {
+    setSettings((prev) => ({ ...prev, size }));
+  }, []);
+
+  const toggleDarkBg = useCallback(() => {
+    setSettings((prev) => ({ ...prev, darkBg: !prev.darkBg }));
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ type: "spring", duration: 0.3 }}
+            className="supports-[corner-shape:squircle]:corner-squircle relative w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-[24px] bg-white p-8 shadow-2xl supports-[corner-shape:squircle]:rounded-[36px] dark:bg-neutral-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="mb-8 flex items-center justify-between">
+              <div>
+                <h2 className="font-sans text-2xl font-semibold text-foreground">
+                  Customize Icon
+                </h2>
+                <p className="mt-1 font-mono text-neutral-500 text-sm">
+                  {iconName}
+                </p>
+              </div>
+              <button
+                onClick={onClose}
+                className="supports-[corner-shape:squircle]:corner-squircle flex size-10 items-center justify-center rounded-[14px] bg-neutral-100 transition-colors hover:bg-neutral-200 supports-[corner-shape:squircle]:rounded-[20px] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+                aria-label="Close modal"
+              >
+                <span className="font-sans text-xl">×</span>
+              </button>
+            </div>
+
+            <div className="grid gap-8 md:grid-cols-2">
+              {/* Preview Section */}
+              <div className="flex flex-col gap-4">
+                <div
+                  className={cn(
+                    "supports-[corner-shape:squircle]:corner-squircle flex min-h-[300px] items-center justify-center rounded-[20px] p-8 transition-colors supports-[corner-shape:squircle]:rounded-[30px]",
+                    settings.darkBg
+                      ? "bg-neutral-900"
+                      : "bg-neutral-100 dark:bg-neutral-800"
+                  )}
+                >
+                  <div style={{ color: settings.color }}>
+                    <IconComponent
+                      size={settings.size}
+                      className="flex items-center justify-center"
+                    />
+                  </div>
+                </div>
+
+                {/* Preview Controls */}
+                <div className="flex items-center justify-center gap-2">
+                  <button
+                    onClick={toggleDarkBg}
+                    className="supports-[corner-shape:squircle]:corner-squircle rounded-[12px] bg-neutral-100 px-4 py-2 font-sans text-sm transition-colors hover:bg-neutral-200 supports-[corner-shape:squircle]:rounded-[18px] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+                  >
+                    {settings.darkBg ? "Light BG" : "Dark BG"}
+                  </button>
+                </div>
+              </div>
+
+              {/* Controls Section */}
+              <div className="flex flex-col gap-6">
+                {/* Color */}
+                <div>
+                  <label className="mb-3 block font-sans text-sm font-medium">
+                    Color
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      type="color"
+                      value={settings.color}
+                      onChange={(e) => handleColorChange(e.target.value)}
+                      className="h-10 w-16 cursor-pointer rounded-[12px]"
+                      style={{ padding: 0 }}
+                    />
+                    <input
+                      type="text"
+                      value={settings.color}
+                      onChange={(e) => handleColorChange(e.target.value)}
+                      className="supports-[corner-shape:squircle]:corner-squircle flex-1 rounded-[12px] border-0 bg-neutral-100 px-3 py-2 font-mono text-sm supports-[corner-shape:squircle]:rounded-[18px] dark:bg-neutral-800"
+                      placeholder="#FFFFFF"
+                    />
+                  </div>
+                  <div className="mt-3 flex gap-2">
+                    {PRESET_COLORS.map((color) => (
+                      <button
+                        key={color}
+                        onClick={() => handleColorChange(color)}
+                        className={cn(
+                          "size-8 rounded-full transition-all hover:scale-110",
+                          settings.color.toUpperCase() === color.toUpperCase()
+                            ? "ring-2 ring-primary ring-offset-2 dark:ring-offset-neutral-900"
+                            : "ring-1 ring-neutral-200 dark:ring-neutral-700"
+                        )}
+                        style={{ backgroundColor: color }}
+                        aria-label={`Set color to ${color}`}
+                      />
+                    ))}
+                  </div>
+                  <p className="mt-2 text-neutral-500 text-xs">
+                    Note: Color is applied via CSS, not as a prop
+                  </p>
+                </div>
+
+                {/* Size */}
+                <div>
+                  <label className="mb-3 flex items-center justify-between font-sans text-sm font-medium">
+                    <span className="flex items-center gap-2">
+                      <Maximize2 className="size-4 text-neutral-400" />
+                      Size
+                    </span>
+                    <span className="font-mono text-neutral-500 text-xs">{settings.size}px</span>
+                  </label>
+                  <input
+                    type="range"
+                    min="16"
+                    max="128"
+                    value={settings.size}
+                    onChange={(e) => handleSizeChange(Number(e.target.value))}
+                    className="w-full accent-primary"
+                  />
+                </div>
+
+                {/* Action Buttons */}
+                <div className="mt-4 flex gap-2">
+                  <button
+                    onClick={handleCopyCustomCode}
+                    className="supports-[corner-shape:squircle]:corner-squircle flex flex-1 items-center justify-center gap-2 rounded-[12px] bg-primary px-4 py-3 font-sans text-sm text-white transition-opacity hover:opacity-90 supports-[corner-shape:squircle]:rounded-[18px]"
+                  >
+                    <Copy className="size-4" />
+                    Copy Full Code
+                  </button>
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleReset}
+                    className="supports-[corner-shape:squircle]:corner-squircle flex flex-1 items-center justify-center gap-2 rounded-[12px] bg-neutral-100 px-4 py-2.5 font-sans text-sm transition-colors hover:bg-neutral-200 supports-[corner-shape:squircle]:rounded-[18px] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+                  >
+                    <RotateCcw className="size-4" />
+                    Reset
+                  </button>
+                  <button
+                    onClick={handleRandomize}
+                    className="supports-[corner-shape:squircle]:corner-squircle flex flex-1 items-center justify-center gap-2 rounded-[12px] bg-neutral-100 px-4 py-2.5 font-sans text-sm transition-colors hover:bg-neutral-200 supports-[corner-shape:squircle]:rounded-[18px] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+                  >
+                    <Shuffle className="size-4" />
+                    Random
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Keyboard Shortcuts Hint */}
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-neutral-400 text-sm dark:text-neutral-500">
+              <span className="flex items-center gap-2">
+                <kbd className="supports-[corner-shape:squircle]:corner-squircle min-w-[28px] rounded-[8px] bg-neutral-100 px-2 py-1 text-center font-mono text-xs font-semibold text-neutral-700 shadow-sm supports-[corner-shape:squircle]:rounded-[12px] dark:bg-neutral-800 dark:text-neutral-300">esc</kbd>
+                <span>close</span>
+              </span>
+              <span className="flex items-center gap-2">
+                <kbd className="supports-[corner-shape:squircle]:corner-squircle min-w-[28px] rounded-[8px] bg-neutral-100 px-2 py-1 text-center font-mono text-xs font-semibold text-neutral-700 shadow-sm supports-[corner-shape:squircle]:rounded-[12px] dark:bg-neutral-800 dark:text-neutral-300">c</kbd>
+                <span>copy</span>
+              </span>
+              <span className="flex items-center gap-2">
+                <kbd className="supports-[corner-shape:squircle]:corner-squircle min-w-[28px] rounded-[8px] bg-neutral-100 px-2 py-1 text-center font-mono text-xs font-semibold text-neutral-700 shadow-sm supports-[corner-shape:squircle]:rounded-[12px] dark:bg-neutral-800 dark:text-neutral-300">r</kbd>
+                <span>reset</span>
+              </span>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+
+

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import Fuse from "fuse.js";
-import { useDeferredValue, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useMemo, useRef, useState, useCallback, memo } from "react";
 import type { Icon } from "@/actions/get-icons";
 
 import { Card, CardActions, CardTitle } from "@/components/card";
+import { CategoryFilter, CATEGORIES } from "@/components/category-filter";
+import { IconCustomizerModal } from "@/components/icon-customizer-modal";
 import { ICON_LIST } from "@/icons";
 import { SearchInput } from "./search-input";
 
@@ -14,12 +16,14 @@ type Props = {
 
 const ICON_MAP = new Map(ICON_LIST.map((item) => [item.name, item.icon]));
 
-const IconItem = ({
+const IconItem = memo(({
   icon,
   Icon,
+  onCustomizeClick,
 }: {
   icon: Icon;
   Icon: React.ElementType | undefined;
+  onCustomizeClick: () => void;
 }) => {
   const animationRef = useRef<{
     startAnimation: () => void;
@@ -43,15 +47,26 @@ const IconItem = ({
         ref={animationRef}
       />
       <CardTitle>{icon.name}</CardTitle>
-      <CardActions {...icon} />
+      <CardActions {...icon} onCustomizeClick={onCustomizeClick} />
     </Card>
   );
-};
+});
+
+IconItem.displayName = "IconItem";
 
 const IconsList = ({ icons }: Props) => {
   const [searchValue, setSearchValue] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const [customizerOpen, setCustomizerOpen] = useState(false);
+  const [selectedIcon, setSelectedIcon] = useState<{ name: string; component: React.ElementType } | null>(null);
   const deferredSearchValue = useDeferredValue(searchValue);
+
+  const handleCustomizeClick = useCallback((iconName: string, IconComponent: React.ElementType) => {
+    setSelectedIcon({ name: iconName, component: IconComponent });
+    setCustomizerOpen(true);
+  }, []);
 
   const fuse = useMemo(
     () =>
@@ -70,32 +85,77 @@ const IconsList = ({ icons }: Props) => {
   );
 
   const filteredIcons = useMemo(() => {
-    if (!deferredSearchValue.trim()) return icons;
-    return fuse.search(deferredSearchValue).map((result) => result.item);
-  }, [fuse, icons, deferredSearchValue]);
+    let result = icons;
+
+    // Apply category filter
+    if (selectedCategory !== "all") {
+      const category = CATEGORIES.find((c) => c.id === selectedCategory);
+      if (category) {
+        result = result.filter((icon) =>
+          icon.keywords.some((keyword) =>
+            category.keywords.some((catKeyword) =>
+              keyword.toLowerCase().includes(catKeyword.toLowerCase())
+            )
+          )
+        );
+      }
+    }
+
+    // Apply search filter
+    if (deferredSearchValue.trim()) {
+      const searchResults = fuse.search(deferredSearchValue);
+      const searchedIcons = searchResults.map((r) => r.item);
+      result = result.filter((icon) =>
+        searchedIcons.some((si) => si.name === icon.name)
+      );
+    }
+
+    return result;
+  }, [icons, selectedCategory, deferredSearchValue, fuse]);
 
   return (
     <div className="mb-20 w-full">
-      <SearchInput
-        searchOpen={searchOpen}
-        searchValue={searchValue}
-        setSearchOpen={setSearchOpen}
-        setSearchValue={setSearchValue}
-      />
+      <div className="flex items-center justify-between px-4 pb-2">
+        <CategoryFilter
+          selectedCategory={selectedCategory}
+          onCategoryChange={setSelectedCategory}
+          categoryOpen={categoryOpen}
+          setCategoryOpen={setCategoryOpen}
+        />
+        <SearchInput
+          searchOpen={searchOpen}
+          searchValue={searchValue}
+          setSearchOpen={setSearchOpen}
+          setSearchValue={setSearchValue}
+        />
+      </div>
       <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-[3px]">
         {filteredIcons.length === 0 && (
           <div className="col-span-full pt-10 text-center text-neutral-500 text-sm">
             No icons found
           </div>
         )}
-        {filteredIcons.map((icon) => (
-          <IconItem
-            Icon={ICON_MAP.get(icon.name) ?? undefined}
-            icon={icon}
-            key={icon.name}
-          />
-        ))}
+        {filteredIcons.map((icon) => {
+          const IconComponent = ICON_MAP.get(icon.name);
+          return IconComponent ? (
+            <IconItem
+              Icon={IconComponent}
+              icon={icon}
+              key={icon.name}
+              onCustomizeClick={() => handleCustomizeClick(icon.name, IconComponent)}
+            />
+          ) : null;
+        })}
       </div>
+
+      {selectedIcon && (
+        <IconCustomizerModal
+          isOpen={customizerOpen}
+          onClose={() => setCustomizerOpen(false)}
+          iconName={selectedIcon.name}
+          IconComponent={selectedIcon.component}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- Add category filter with keyboard shortcut (C)
  - 9 categories: All, UI, Arrows, Files, Social, Communication, Media, Weather, Symbols
  - Fullscreen overlay with backdrop blur
  - ESC to close

- Add icon customizer modal
  - Live preview with color and size adjustments
  - Color picker with preset colors
  - Size slider (16-128px)
  - Copy full icon code with custom settings applied
  - Keyboard shortcuts: ESC (close), C (copy), R (reset)

- Add Settings button to icon cards
- Remove Christmas logo from header
- Performance optimizations with React.memo and useCallback