### PR TITLE
implement localStorage functionality in PackageNameProvider

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -46,4 +46,6 @@ const PACKAGE_MANAGER = {
   BUN: "bun",
 } as const;
 
-export { LINK, PACKAGE_MANAGER, SITE };
+const STORAGE_KEY = "selectedPackageManager";
+
+export { LINK, PACKAGE_MANAGER, SITE, STORAGE_KEY };

--- a/providers/package-name.tsx
+++ b/providers/package-name.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { createContext, useContext, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
-import { PACKAGE_MANAGER } from "@/constants";
+import { PACKAGE_MANAGER, STORAGE_KEY } from "@/constants";
 
 type PackageManager = (typeof PACKAGE_MANAGER)[keyof typeof PACKAGE_MANAGER];
 
@@ -19,9 +25,24 @@ const PackageNameContext = createContext<PackageNameContextType>({
 });
 
 const PackageNameProvider = ({ children }: { children: React.ReactNode }) => {
-  const [packageName, setPackageName] = useState<PackageManager>(
+  const [packageName, setPackageNameState] = useState<PackageManager>(
     PACKAGE_MANAGER.PNPM
   );
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as PackageManager | null;
+    if (stored && Object.values(PACKAGE_MANAGER).includes(stored)) {
+      setPackageNameState(stored);
+    }
+  }, []);
+
+  const setPackageName = useCallback((value: PackageManager) => {
+    setPackageNameState(value);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, value);
+    }
+  }, []);
+
 
   return (
     <PackageNameContext.Provider value={{ packageName, setPackageName }}>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/pqoqubbw/icons/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

feature

## What is the new behavior?

saves the selected package manager in localStorage so it stays selected after a page reload.
saves lot of clicks ;3

## Demo

![demo](https://github.com/user-attachments/assets/17ec356f-4277-4a53-bb3e-5f4b76ad5769)


## Additional context
only the provider was changed, no hydration issues.

