### PR TITLE
feat(icons): add 50 animated lucide icons

### DIFF
--- a/icons/alarm-clock-check.tsx
+++ b/icons/alarm-clock-check.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface AlarmClockCheckIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AlarmClockCheckIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SECONDARY_PATH_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    x: 0,
+    transition: {
+      duration: 0.2,
+      type: "spring",
+      stiffness: 200,
+      damping: 25,
+    },
+  },
+  animate: {
+    y: -2.5,
+    x: [-2, 2, -2, 2, -2, 0],
+    transition: {
+      y: {
+        duration: 0.2,
+        type: "spring",
+        stiffness: 200,
+        damping: 25,
+      },
+      x: {
+        duration: 0.3,
+        repeat: Number.POSITIVE_INFINITY,
+        ease: "linear",
+      },
+    },
+  },
+};
+
+const CHECK_VARIANTS: Variants = {
+  normal: { pathLength: 1, y: 0 },
+  animate: {
+    pathLength: [0, 1],
+    y: [-2],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const AlarmClockCheckIcon = forwardRef<
+  AlarmClockCheckIconHandle,
+  AlarmClockCheckIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ overflow: "visible" }}
+      >
+        <motion.circle
+          cx="12"
+          cy="13"
+          r="8"
+          animate={controls}
+          initial="normal"
+          variants={SECONDARY_PATH_VARIANTS}
+        />
+        <motion.path
+          d="M5 3 2 6"
+          animate={controls}
+          initial="normal"
+          variants={SECONDARY_PATH_VARIANTS}
+        />
+        <motion.path
+          d="m22 6-3-3"
+          animate={controls}
+          initial="normal"
+          variants={SECONDARY_PATH_VARIANTS}
+        />
+        <motion.path
+          d="M6.38 18.7 4 21"
+          animate={controls}
+          initial="normal"
+          variants={SECONDARY_PATH_VARIANTS}
+        />
+        <motion.path
+          d="M17.64 18.67 20 21"
+          animate={controls}
+          initial="normal"
+          variants={SECONDARY_PATH_VARIANTS}
+        />
+        <motion.path
+          d="m9 13 2 2 4-4"
+          animate={controls}
+          initial="normal"
+          variants={CHECK_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+AlarmClockCheckIcon.displayName = "AlarmClockCheckIcon";
+
+export { AlarmClockCheckIcon };

--- a/icons/alarm-clock-minus.tsx
+++ b/icons/alarm-clock-minus.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface AlarmClockMinusIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AlarmClockMinusIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ALARAM_CLOCK_MINUS_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    x: 0,
+    transition: {
+      duration: 0.2,
+      type: "spring",
+      stiffness: 200,
+      damping: 25,
+    },
+  },
+  animate: {
+    y: -2.5,
+    x: [-2, 2, -2, 2, -2, 0],
+    transition: {
+      y: {
+        duration: 0.2,
+        type: "spring",
+        stiffness: 200,
+        damping: 25,
+      },
+      x: {
+        duration: 0.3,
+        repeat: Number.POSITIVE_INFINITY,
+        ease: "linear",
+      },
+    },
+  },
+};
+
+const AlarmClockMinusIcon = forwardRef<
+  AlarmClockMinusIconHandle,
+  AlarmClockMinusIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ overflow: "visible" }}
+      >
+        <motion.circle
+          cx="12"
+          cy="13"
+          r="8"
+          animate={controls}
+          initial="normal"
+          variants={ALARAM_CLOCK_MINUS_VARIANTS}
+        />
+        <motion.path
+          d="M5 3 2 6"
+          animate={controls}
+          initial="normal"
+          variants={ALARAM_CLOCK_MINUS_VARIANTS}
+        />
+        <motion.path
+          d="m22 6-3-3"
+          animate={controls}
+          initial="normal"
+          variants={ALARAM_CLOCK_MINUS_VARIANTS}
+        />
+        <motion.path
+          d="M6.38 18.7 4 21"
+          animate={controls}
+          initial="normal"
+          variants={ALARAM_CLOCK_MINUS_VARIANTS}
+        />
+        <motion.path
+          d="M17.64 18.67 20 21"
+          animate={controls}
+          initial="normal"
+          variants={ALARAM_CLOCK_MINUS_VARIANTS}
+        />
+        <motion.path
+          d="M9 13h6"
+          animate={controls}
+          initial="normal"
+          variants={ALARAM_CLOCK_MINUS_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+AlarmClockMinusIcon.displayName = "AlarmClockMinusIcon";
+
+export { AlarmClockMinusIcon };

--- a/icons/alarm-clock-plus.tsx
+++ b/icons/alarm-clock-plus.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface AlarmClockPlusIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AlarmClockPlusIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ALARM_CLOCK_PLUS_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    x: 0,
+    transition: {
+      duration: 0.2,
+      type: "spring",
+      stiffness: 200,
+      damping: 25,
+    },
+  },
+  animate: {
+    y: -2.5,
+    x: [-2, 2, -2, 2, -2, 0],
+    transition: {
+      y: {
+        duration: 0.2,
+        type: "spring",
+        stiffness: 200,
+        damping: 25,
+      },
+      x: {
+        duration: 0.3,
+        repeat: Number.POSITIVE_INFINITY,
+        ease: "linear",
+      },
+    },
+  },
+};
+
+const PLUS_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    y: 0,
+  },
+  animate: {
+    rotate: 180, 
+    y: -2,
+    transition: {
+      rotate: {
+        duration: 0.4,
+        ease: "easeInOut",
+      },
+      y: {
+        duration: 0.2,
+        type: "spring",
+        stiffness: 200,
+        damping: 20,
+      },
+    },
+  },
+};
+
+const AlarmClockPlusIcon = forwardRef<
+  AlarmClockPlusIconHandle,
+  AlarmClockPlusIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ overflow: "visible" }}
+      >
+        <motion.circle
+          cx="12"
+          cy="13"
+          r="8"
+          animate={controls}
+          initial="normal"
+          variants={ALARM_CLOCK_PLUS_VARIANTS}
+        />
+        <motion.path
+          d="M5 3 2 6"
+          animate={controls}
+          initial="normal"
+          variants={ALARM_CLOCK_PLUS_VARIANTS}
+        />
+        <motion.path
+          d="m22 6-3-3"
+          animate={controls}
+          initial="normal"
+          variants={ALARM_CLOCK_PLUS_VARIANTS}
+        />
+        <motion.path
+          d="M6.38 18.7 4 21"
+          animate={controls}
+          initial="normal"
+          variants={ALARM_CLOCK_PLUS_VARIANTS}
+        />
+        <motion.path
+          d="M17.64 18.67 20 21"
+          animate={controls}
+          initial="normal"
+          variants={ALARM_CLOCK_PLUS_VARIANTS}
+        />
+        <motion.g animate={controls} initial="normal" variants={PLUS_VARIANTS}>
+          <path d="M12 10v6" />
+          <path d="M9 13h6" />
+        </motion.g>
+      </motion.svg>
+    </div>
+  );
+});
+
+AlarmClockPlusIcon.displayName = "AlarmClockPlusIcon";
+
+export { AlarmClockPlusIcon };

--- a/icons/alarm-smoke.tsx
+++ b/icons/alarm-smoke.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface AlarmSmokeIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AlarmSmokeIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ALARM_SMOKE_VIBRATE_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    x: 0,
+    transition: {
+      duration: 0.2,
+      type: "spring",
+      stiffness: 200,
+      damping: 25,
+    },
+  },
+  animate: {
+    y: -2.5,
+    x: [-2, 2, -2, 2, 0],
+    transition: {
+      y: {
+        duration: 0.2,
+        type: "spring",
+        stiffness: 200,
+        damping: 25,
+      },
+      x: {
+        duration: 0.3,
+        repeat: Number.POSITIVE_INFINITY,
+        ease: "linear",
+      },
+    },
+  },
+};
+
+const ALARAM_SMOKE_VARIANTS: Variants = {
+  normal: { pathLength: 1, y: 0 },
+  animate: {
+    pathLength: [0, 1],
+    y: [-2],
+    opacity: [0, 1, 0],
+    transition: {
+      duration: 1.2,
+      ease: "easeInOut",
+      repeat: Infinity,
+      repeatType: "loop",
+    },
+  },
+};
+
+const AlarmSmokeIcon = forwardRef<AlarmSmokeIconHandle, AlarmSmokeIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ overflow: "visible" }}
+        >
+          <motion.path
+            d="M11 21c0-2.5 2-2.5 2-5"
+            animate={controls}
+            initial="normal"
+            variants={ALARAM_SMOKE_VARIANTS}
+          />
+          <motion.path
+            d="M16 21c0-2.5 2-2.5 2-5"
+            animate={controls}
+            initial="normal"
+            variants={ALARAM_SMOKE_VARIANTS}
+          />
+          <motion.g
+            animate={controls}
+            initial="normal"
+            variants={ALARM_SMOKE_VIBRATE_VARIANTS}
+          >
+            <motion.path d="m19 8-.8 3a1.25 1.25 0 0 1-1.2 1H7a1.25 1.25 0 0 1-1.2-1L5 8" />
+            <motion.path d="M21 3a1 1 0 0 1 1 1v2a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a1 1 0 0 1 1-1z" />
+          </motion.g>
+          <motion.path
+            d="M6 21c0-2.5 2-2.5 2-5"
+            animate={controls}
+            initial="normal"
+            variants={ALARAM_SMOKE_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+AlarmSmokeIcon.displayName = "AlarmSmokeIcon";
+
+export { AlarmSmokeIcon };

--- a/icons/antenna.tsx
+++ b/icons/antenna.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface AntennaIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface AntennaIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ANTENNA_VARIANTS: Variants = {
+  normal: {
+    rotateY: 0,
+    scale: 1,
+  },
+  animate: {
+    rotateY: [180, 360, 180, 360],
+    scale: [1, 1.2, 1.1, 1],
+    transition: {
+      rotateX: {
+        duration: 1.2,
+        ease: "easeInOut",
+      },
+      scale: {
+        duration: 0.9,
+        ease: "easeInOut",
+      },
+    },
+  },
+};
+
+const AntennaIcon = forwardRef<AntennaIconHandle, AntennaIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          variants={ANTENNA_VARIANTS}
+        >
+          <path d="M2 12 7 2" />
+          <path d="m7 12 5-10" />
+          <path d="m12 12 5-10" />
+          <path d="m17 12 5-10" />
+          <path d="M4.5 7h15" />
+          <path d="M12 16v6" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+AntennaIcon.displayName = "AntennaIcon";
+
+export { AntennaIcon };

--- a/icons/cigarette-off.tsx
+++ b/icons/cigarette-off.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface CigaretteOffIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface CigaretteOffIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CIGARETTE_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    opacity: 1,
+  },
+  animate: (custom: number) => ({
+    y: -3,
+    opacity: [0, 1, 0],
+    transition: {
+      repeat: Number.POSITIVE_INFINITY,
+      duration: 1.5,
+      ease: "easeInOut",
+      delay: 0.2 * custom,
+    },
+  }),
+};
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const CigaretteOffIcon = forwardRef<
+  CigaretteOffIconHandle,
+  CigaretteOffIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ overflow: "visible" }}
+      >
+        <path d="M12 12H3a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h13" />
+        <motion.path
+          d="M18 8c0-2.5-2-2.5-2-5"
+          animate={controls}
+          initial="normal"
+          variants={CIGARETTE_VARIANTS}
+        />
+        <motion.path
+          d="m2 2 20 20"
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+        />
+        <motion.path d="M21 12a1 1 0 0 1 1 1v2a1 1 0 0 1-.5.866" />
+        <motion.path
+          d="M22 8c0-2.5-2-2.5-2-5"
+          animate={controls}
+          initial="normal"
+          variants={CIGARETTE_VARIANTS}
+        />
+        <path d="M7 12v4" />
+      </motion.svg>
+    </div>
+  );
+});
+
+CigaretteOffIcon.displayName = "CigaretteOffIcon";
+
+export { CigaretteOffIcon };

--- a/icons/cigarette.tsx
+++ b/icons/cigarette.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface CigaretteIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface CigaretteIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CIGARETTE_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    opacity: 1,
+  },
+  animate: (custom: number) => ({
+    y: -3,
+    opacity: [0, 1, 0],
+    transition: {
+      repeat: Number.POSITIVE_INFINITY,
+      duration: 1.5,
+      ease: "easeInOut",
+      delay: 0.2 * custom,
+    },
+  }),
+};
+
+const CigaretteIcon = forwardRef<CigaretteIconHandle, CigaretteIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ overflow: "visible" }}
+        >
+          <path d="M17 12H3a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h14" />
+          <motion.path
+            d="M18 8c0-2.5-2-2.5-2-5"
+            animate={controls}
+            custom={0.1}
+            initial="normal"
+            variants={CIGARETTE_VARIANTS}
+          />
+          <path d="M21 16a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1" />
+          <motion.path
+            d="M22 8c0-2.5-2-2.5-2-5"
+            animate={controls}
+            custom={0.3}
+            initial="normal"
+            variants={CIGARETTE_VARIANTS}
+          />
+          <path d="M7 12v4" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+CigaretteIcon.displayName = "CigaretteIcon";
+
+export { CigaretteIcon };

--- a/icons/dam.tsx
+++ b/icons/dam.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface DamIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface DamIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DamIcon = forwardRef<DamIconHandle, DamIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+        >
+          <motion.path
+            d="M11 11.31c1.17.56 1.54 1.69 3.5 1.69 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.4, ease: "linear" },
+              },
+            }}
+          />
+          <motion.path
+            d="M11.75 18c.35.5 1.45 1 2.75 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.4, ease: "linear" },
+              },
+            }}
+          />
+          <motion.path
+            d="M2 10h4"
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.4, ease: "linear" },
+              },
+            }}
+          />
+          <motion.path
+            d="M2 14h4"
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.4, ease: "linear" },
+              },
+            }}
+          />
+          <motion.path
+            d="M2 18h4"
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.4, ease: "linear" },
+              },
+            }}
+          />
+          <motion.path
+            d="M2 6h4"
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.4, ease: "linear" },
+              },
+            }}
+          />
+          <path d="M7 3a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1L10 4a1 1 0 0 0-1-1z" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+DamIcon.displayName = "DamIcon";
+
+export { DamIcon };

--- a/icons/flower-2.tsx
+++ b/icons/flower-2.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface Flower2IconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface Flower2IconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const FLOWER_2_VARIANTS: Variants = {
+  normal: {
+    rotateY: 0,
+    scale: 1,
+  },
+  animate: {
+    rotateY: [180, 360, 180, 360],
+    scale: [1, 1.2, 1.1, 1],
+    transition: {
+      rotateX: {
+        duration: 0.9,
+        ease: "easeInOut",
+      },
+      scale: {
+        duration: 0.6,
+        ease: "easeInOut",
+      },
+    },
+  },
+};
+
+const Flower2Icon = forwardRef<Flower2IconHandle, Flower2IconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          variants={FLOWER_2_VARIANTS}
+        >
+          <motion.path d="M12 5a3 3 0 1 1 3 3m-3-3a3 3 0 1 0-3 3m3-3v1M9 8a3 3 0 1 0 3 3M9 8h1m5 0a3 3 0 1 1-3 3m3-3h-1m-2 3v-1" />
+          <circle cx="12" cy="8" r="2" />
+          <path d="M12 10v12" />
+          <path d="M12 22c4.2 0 7-1.667 7-5-4.2 0-7 1.667-7 5Z" />
+          <path d="M12 22c-4.2 0-7-1.667-7-5 4.2 0 7 1.667 7 5Z" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+Flower2Icon.displayName = "Flower2Icon";
+
+export { Flower2Icon };

--- a/icons/flower.tsx
+++ b/icons/flower.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface FlowerIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface FlowerIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const FLOWER_VARIANTS = {
+  initial: {
+    scale: 1,
+    rotate: 0,
+  },
+  animate: {
+    scale: [1, 1.02, 1.04, 1],
+    rotate: [0, 45, 90],
+  },
+};
+const FlowerIcon = forwardRef<FlowerIconHandle, FlowerIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          initial="initial"
+          animate={controls}
+          variants={FLOWER_VARIANTS}
+        >
+          <circle cx="12" cy="12" r="3" />
+          <motion.path
+            d="M12 16.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 1 1 12 7.5a4.5 4.5 0 1 1 4.5 4.5 4.5 4.5 0 1 1-4.5 4.5"
+            animate={controls}
+            initial={{ pathLength: 1 }}
+            variants={{
+              normal: { pathLength: 1 },
+              animate: {
+                pathLength: [0, 1],
+                transition: { duration: 0.9, ease: "linear" },
+              },
+            }}
+          />
+          <motion.path d="M12 7.5V9" />
+          <motion.path d="M7.5 12H9" />
+          <motion.path d="M16.5 12H15" />
+          <motion.path d="M12 16.5V15" />
+          <motion.path d="M14.12 9.88 16 8" />
+          <motion.path d="m8 8 1.88 1.88" />
+          <motion.path d="m8 16 1.88-1.88" />
+          <motion.path d="M14.12 14.12 16 16" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+FlowerIcon.displayName = "FlowerIcon";
+
+export { FlowerIcon };

--- a/icons/gamepad-directional.tsx
+++ b/icons/gamepad-directional.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface GamepadDirectionalIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GamepadDirectionalIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const GAMEPAD_VARIANTS: Variants = {
+  normal: { rotate: 0 },
+  animate: {
+    rotate: [0, 360],
+    transition: {
+      duration: 0.8,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const GAMEPAD_PATH1_VARIANTS: Variants = {
+  normal: { x: 0, y: 0 },
+  animate: {
+    y: [-10, 0],
+    transition: { duration: 0.22, ease: "easeOut", delay: 0 },
+  },
+};
+
+const GAMEPAD_PATH2_VARIANTS: Variants = {
+  normal: { x: 0, y: 0 },
+  animate: {
+    x: [10, 0],
+    transition: { duration: 0.22, ease: "easeOut", delay: 0.05 },
+  },
+};
+
+const GAMEPAD_PATH3_VARIANTS: Variants = {
+  normal: { x: 0, y: 0 },
+  animate: {
+    x: [-10, 0],
+    transition: { duration: 0.22, ease: "easeOut", delay: 0.1 },
+  },
+};
+
+const GAMEPAD_PATH4_VARIANTS: Variants = {
+  normal: { x: 0, y: 0 },
+  animate: {
+    y: [10, 0],
+    transition: { duration: 0.22, ease: "easeOut", delay: 0.15 },
+  },
+};
+
+const GamepadDirectionalIcon = forwardRef<
+  GamepadDirectionalIconHandle,
+  GamepadDirectionalIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = ref != null;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  }, [controls, ref]);
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseEnter?.(e);
+      } else {
+        controls.start("animate");
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseLeave?.(e);
+      } else {
+        controls.start("normal");
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        className="overflow-visible"
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.g
+          animate={controls}
+          initial="normal"
+          style={{ transformOrigin: "12px 12px" }}
+          variants={GAMEPAD_VARIANTS}
+        >
+          <motion.path
+            d="M11.146 15.854a1.207 1.207 0 0 1 1.708 0l1.56 1.56A2 2 0 0 1 15 18.828V21a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-2.172a2 2 0 0 1 .586-1.414z"
+            animate={controls}
+            initial="normal"
+            variants={GAMEPAD_PATH4_VARIANTS}
+          />
+          <motion.path
+            d="M18.828 15a2 2 0 0 1-1.414-.586l-1.56-1.56a1.207 1.207 0 0 1 0-1.708l1.56-1.56A2 2 0 0 1 18.828 9H21a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1z"
+            animate={controls}
+            initial="normal"
+            variants={GAMEPAD_PATH2_VARIANTS}
+          />
+          <motion.path
+            d="M6.586 14.414A2 2 0 0 1 5.172 15H3a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h2.172a2 2 0 0 1 1.414.586l1.56 1.56a1.207 1.207 0 0 1 0 1.708z"
+            animate={controls}
+            initial="normal"
+            variants={GAMEPAD_PATH3_VARIANTS}
+          />
+          <motion.path
+            d="M9 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2.172a2 2 0 0 1-.586 1.414l-1.56 1.56a1.207 1.207 0 0 1-1.708 0l-1.56-1.56A2 2 0 0 1 9 5.172z"
+            animate={controls}
+            initial="normal"
+            variants={GAMEPAD_PATH1_VARIANTS}
+          />
+        </motion.g>
+      </svg>
+    </div>
+  );
+});
+
+GamepadDirectionalIcon.displayName = "GamepadDirectionalIcon";
+
+export { GamepadDirectionalIcon };

--- a/icons/index.ts
+++ b/icons/index.ts
@@ -192,6 +192,7 @@ import { KeyboardIcon } from "@/icons/keyboard";
 import { LanguagesIcon } from "@/icons/languages";
 import { LaptopMinimalCheckIcon } from "@/icons/laptop-minimal-check";
 import { LaughIcon } from "@/icons/laugh";
+import { LeafIcon } from "@/icons/leaf";
 import { LayersIcon } from "@/icons/layers";
 import { LayoutGridIcon } from "@/icons/layout-grid";
 import { LayoutPanelTopIcon } from "@/icons/layout-panel-top";
@@ -402,6 +403,56 @@ import { HandMetalIcon } from "./hand-metal";
 import { HeartHandshakeIcon } from "./heart-handshake";
 import { HeartPulseIcon } from "./heart-pulse";
 import { TruckIcon } from "./truck";
+import { LeafyGreenIcon } from "./leafy-green";
+import { RecycleIcon } from "./recycle";
+import { WavesArrowDownIcon } from "./waves-arrow-down";
+import { WavesArrowUpIcon } from "./waves-arrow-up";
+import { TreePineIcon } from "./tree-pine";
+import { TreeDeciduousIcon } from "./tree-deciduous";
+import { UtilityPoleIcon } from "./utility-pole";
+import { DamIcon } from "./dam";
+import { FlowerIcon } from "./flower";
+import { Flower2Icon } from "./flower-2";
+import { AlarmClockCheckIcon } from "./alarm-clock-check";
+import { AlarmClockMinusIcon } from "./alarm-clock-minus";
+import { AlarmClockPlusIcon } from "./alarm-clock-plus";
+import { AlarmSmokeIcon } from "./alarm-smoke";
+import { AntennaIcon } from "./antenna";
+import { PhoneIcon } from "./phone";
+import { PhoneCallIcon } from "./phone-call";
+import { PhoneForwardedIcon } from "./phone-forwarded";
+import { PhoneIncomingIcon } from "./phone-incoming";
+import { PhoneMissedIcon } from "./phone-missed";
+import { PhoneOffIcon } from "./phone-off";
+import { PhoneOutgoingIcon } from "./phone-outgoing";
+import { RouterIcon } from "./router";
+import { SatelliteDishIcon } from "./satellite-dish";
+import { ProjectorIcon } from "./projector";
+import { SpotlightIcon } from "./spotlight";
+import { SwitchCameraIcon } from "./switch-camera";
+import { WifiCogIcon } from "./wifi-cog";
+import { WifiSyncIcon } from "./wifi-sync";
+import { WifiPenIcon } from "./wifi-pen";
+import { ServerIcon } from "./server";
+import { ServerCogIcon } from "./server-cog";
+import { ServerCrashIcon } from "./server-crash";
+import { ServerOffIcon } from "./server-off";
+import { GamepadDirectionalIcon } from "./gamepad-directional";
+import { CigaretteIcon } from "./cigarette";
+import { CigaretteOffIcon } from "./cigarette-off";
+import { ReceiptIcon } from "./receipt";
+import { ReceiptCentIcon } from "./receipt-cent";
+import { ReceiptEuroIcon } from "./receipt-euro";
+import { ReceiptIndianRupeeIcon } from "./receipt-indian-rupee";
+import { ReceiptJapaneseYenIcon } from "./receipt-japanese-yen";
+import { ReceiptPoundSterlingIcon } from "./receipt-pound-sterling";
+import { ReceiptRussianRubleIcon } from "./receipt-russian-ruble";
+import { ReceiptSwissFrancIcon } from "./receipt-swiss-franc";
+import { ReceiptTextIcon } from "./receipt-text";
+import { ReceiptTurkishLiraIcon } from "./receipt-turkish-lira";
+import { ShipWheelIcon } from "./ship-wheel";
+import { PlaneTakeoffIcon } from "./plane-takeoff";
+import { PlaneLandingIcon } from "./plane-landing";
 
 type IconListItem = {
   name: string;
@@ -410,6 +461,267 @@ type IconListItem = {
 };
 
 const ICON_LIST: IconListItem[] = [
+  {
+    name: "leaf",
+    icon: LeafIcon,
+    keywords: ["leaf", "tree", "plant", "nature", "green"],
+  },
+  {
+    name: "leafy-green",
+    icon: LeafyGreenIcon,
+    keywords: ["leaf", "tree", "plant", "nature", "green"],
+  },
+  {
+    name: "recycle",
+    icon: RecycleIcon,
+    keywords: ["recycle", "trash", "garbage", "waste", "recycling"],
+  },
+  {
+    name: "tree-pine",
+    icon: TreePineIcon,
+    keywords: ["tree", "pine", "forest", "nature", "green"],
+  },
+  {
+    name: "waves-arrow-down",
+    icon: WavesArrowDownIcon,
+    keywords: ["waves", "arrow", "down", "navigation", "scroll"],
+  },
+  {
+    name: "waves-arrow-up",
+    icon: WavesArrowUpIcon,
+    keywords: ["waves", "arrow", "up", "navigation", "scroll"],
+  },
+  {
+    name: "tree-deciduous",
+    icon: TreeDeciduousIcon,
+    keywords: ["tree", "deciduous", "forest", "nature", "green"],
+  },
+  {
+    name: "utility-pole",
+    icon: UtilityPoleIcon,
+    keywords: ["utility", "pole", "power", "line", "electricity"],
+  },
+  {
+    name: "dam",
+    icon: DamIcon,
+    keywords: ["dam", "water", "reservoir", "storage", "hydroelectric"],
+  },
+  {
+    name: "flower",
+    icon: FlowerIcon,
+    keywords: ["flower", "plant", "nature", "green"],
+  },
+  {
+    name: "flower-2",
+    icon: Flower2Icon,
+    keywords: ["flower", "plant", "nature", "green"],
+  },
+  {
+    name: "alarm-clock-check",
+    icon: AlarmClockCheckIcon,
+    keywords: ["alarm", "clock", "check", "time", "schedule"],
+  },
+  {
+    name: "alarm-clock-minus",
+    icon: AlarmClockMinusIcon,
+    keywords: ["alarm", "clock", "check", "time", "schedule"],
+  },
+  {
+    name: "alarm-smoke",
+    icon: AlarmSmokeIcon,
+    keywords: ["alarm", "smoke", "fire", "smoke", "fire alarm"],
+  },
+  {
+    name: "alarm-clock-plus",
+    icon: AlarmClockPlusIcon,
+    keywords: ["alarm", "clock", "check", "time", "schedule"],
+  },
+  {
+    name: "antenna",
+    icon: AntennaIcon,
+    keywords: ["antenna", "radio", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone",
+    icon: PhoneIcon,
+    keywords: ["phone", "call", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone-call",
+    icon: PhoneCallIcon,
+    keywords: ["phone", "call", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone-forward",
+    icon: PhoneForwardedIcon,
+    keywords: ["phone", "forward", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone-incoming",
+    icon: PhoneIncomingIcon,
+    keywords: ["phone", "incoming", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone-missed",
+    icon: PhoneMissedIcon,
+    keywords: ["phone", "missed", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone-off",
+    icon: PhoneOffIcon,
+    keywords: ["phone", "off", "communication", "signal", "wireless"],
+  },
+  {
+    name: "phone-outgoing",
+    icon: PhoneOutgoingIcon,
+    keywords: ["phone", "outgoing", "communication", "signal", "wireless"],
+  },
+  {
+    name: "router",
+    icon: RouterIcon,
+    keywords: ["router", "network", "communication", "signal", "wireless"],
+  },
+  {
+    name: "satellite-dish",
+    icon: SatelliteDishIcon,
+    keywords: ["satellite", "dish", "communication", "signal", "wireless"],
+  },
+  {
+    name: "projector",
+    icon: ProjectorIcon,
+    keywords: ["projector", "screen", "display", "video", "projection"],
+  },
+  {
+    name: "spotlight",
+    icon: SpotlightIcon,
+    keywords: [
+      "spotlight",
+      "light",
+      "brightness",
+      "illumination",
+      "brightness",
+    ],
+  },
+  {
+    name: "switch-camera",
+    icon: SwitchCameraIcon,
+    keywords: ["switch", "camera", "video", "photo", "capture"],
+  },
+  {
+    name: "wifi-cog",
+    icon: WifiCogIcon,
+    keywords: ["wifi", "cog", "settings", "configuration"],
+  },
+  {
+    name: "wifi-sync",
+    icon: WifiSyncIcon,
+    keywords: ["wifi", "sync", "synchronize", "update"],
+  },
+  {
+    name: "wifi-pen",
+    icon: WifiPenIcon,
+    keywords: ["wifi", "pen", "edit", "write"],
+  },
+  {
+    name: "server",
+    icon: ServerIcon,
+    keywords: ["server", "network", "communication", "signal", "wireless"],
+  },
+  {
+    name: "server-cog",
+    icon: ServerCogIcon,
+    keywords: ["server", "network", "communication", "signal", "wireless"],
+  },
+  {
+    name: "server-crash",
+    icon: ServerCrashIcon,
+    keywords: ["server", "network", "communication", "signal", "wireless"],
+  },
+  {
+    name: "server-off",
+    icon: ServerOffIcon,
+    keywords: ["server", "network", "communication", "signal", "wireless"],
+  },
+  {
+    name: "gamepad-directional",
+    icon: GamepadDirectionalIcon,
+    keywords: ["gamepad", "controller", "directional", "navigation", "input"],
+  },
+  {
+    name: "cigarette",
+    icon: CigaretteIcon,
+    keywords: ["cigarette", "smoke", "smoking", "smoke", "smoke icon"],
+  },
+  {
+    name: "cigarette-off",
+    icon: CigaretteOffIcon,
+    keywords: ["cigarette", "smoke", "smoking", "smoke", "smoke icon"],
+  },
+  {
+    name: "receipt",
+    icon: ReceiptIcon,
+    keywords: ["receipt", "invoice", "receipt icon"],
+  },
+  {
+    name: "receipt-cent",
+    icon: ReceiptCentIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "cent", "currency"],
+  },
+  {
+    name: "receipt-euro",
+    icon: ReceiptEuroIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "euro", ],
+  },
+  {
+    name: "receipt-indian-rupee",
+    icon: ReceiptIndianRupeeIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "indian rupee", "rupee"],
+  },
+  {
+    name: "receipt-japanese-yen",
+    icon: ReceiptJapaneseYenIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "japanese yen", "yen"],
+  },
+  {
+    name: "receipt-pound-sterling",
+    icon: ReceiptPoundSterlingIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "pound sterling", "sterling"],
+  },
+  {
+    name: "receipt-russian-ruble",
+    icon: ReceiptRussianRubleIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "russian ruble", "ruble"],
+  },
+  {
+    name: "receipt-swiss-franc",
+    icon: ReceiptSwissFrancIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "swiss franc", "franc"],
+  },
+  {
+    name: "receipt-text",
+    icon: ReceiptTextIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "text"],
+  },
+  {
+    name: "receipt-turkish-lira",
+    icon: ReceiptTurkishLiraIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "turkish lira", "lira"],
+  },
+  {
+    name: "ship-wheel",
+    icon: ShipWheelIcon,
+    keywords: ["ship", "wheel", "navigation", "transportation"],
+  },
+  {
+    name: "plane-takeoff",
+    icon: PlaneTakeoffIcon,
+    keywords: ["plane", "takeoff", "flight", "airplane", "aircraft"],
+  },
+  {
+    name: "plane-landing",
+    icon: PlaneLandingIcon,
+    keywords: ["plane", "landing", "flight", "airplane", "aircraft"],
+  },
   {
     name: "layout-grid",
     icon: LayoutGridIcon,

--- a/icons/leaf.tsx
+++ b/icons/leaf.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface LeafIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LeafIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const leafVariants: Variants = {
+  normal: {
+    rotate: 0,
+    y: 0,
+    x: 0,
+  },
+  animate: {
+    rotate: [0, -8, 4, -3, 0],
+    y: [0, -4, -2, -1, 0],
+    x: [0, 2, -2, 1, 0],
+    transition: {
+      duration: 1.6,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const LeafIcon = forwardRef<LeafIconHandle, LeafIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          animate={controls}
+          initial="normal"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          variants={leafVariants}
+        >
+          <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z" />
+          <path d="M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+LeafIcon.displayName = "LeafIcon";
+
+export { LeafIcon };

--- a/icons/leafy-green.tsx
+++ b/icons/leafy-green.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface LeafyGreenIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LeafyGreenIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const leafyGreenVariants: Variants = {
+  normal: {
+    rotate: 0,
+    y: 0,
+    x: 0,
+  },
+  animate: {
+    rotate: [0, -8, 4, -3, 0],
+    y: [0, -4, -2, -1, 0],
+    x: [0, 2, -2, 1, 0],
+    transition: {
+      duration: 1.6,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const LeafyGreenIcon = forwardRef<LeafyGreenIconHandle, LeafyGreenIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          variants={leafyGreenVariants}
+        >
+          <path d="M2 22c1.25-.987 2.27-1.975 3.9-2.2a5.56 5.56 0 0 1 3.8 1.5 4 4 0 0 0 6.187-2.353 3.5 3.5 0 0 0 3.69-5.116A3.5 3.5 0 0 0 20.95 8 3.5 3.5 0 1 0 16 3.05a3.5 3.5 0 0 0-5.831 1.373 3.5 3.5 0 0 0-5.116 3.69 4 4 0 0 0-2.348 6.155C3.499 15.42 4.409 16.712 4.2 18.1 3.926 19.743 3.014 20.732 2 22" />
+          <path d="M2 22 17 7" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+LeafyGreenIcon.displayName = "LeafyGreenIcon";
+
+export { LeafyGreenIcon };

--- a/icons/phone-call.tsx
+++ b/icons/phone-call.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneCallIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneCallIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PHONE_CALL_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    scale: 1,
+  },
+  animate: {
+    rotate: [10, 20, -10, 10, 0],
+    scale: [1, 1.1, 1.2, 1.1, 1],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    transition: {
+      duration: 0.4,
+    },
+  },
+  fadeOut: {
+    opacity: 0,
+    transition: { duration: 0.3 },
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      type: "spring",
+      stiffness: 300,
+      damping: 20,
+      delay: i * 0.1,
+    },
+  }),
+};
+
+const PhoneCallIcon = forwardRef<PhoneCallIconHandle, PhoneCallIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const svgControls = useAnimation();
+    const pathControls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    const runPathIntro = useCallback(async () => {
+      await pathControls.start("fadeOut");
+      pathControls.start("fadeIn");
+    }, [pathControls]);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: async () => {
+          void svgControls.start("animate");
+          await runPathIntro();
+        },
+        stopAnimation: () => {
+          svgControls.start("normal");
+          pathControls.start("normal");
+        },
+      };
+    }, [pathControls, runPathIntro, ref, svgControls]);
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          void svgControls.start("animate");
+          await runPathIntro();
+        }
+      },
+      [onMouseEnter, runPathIntro, svgControls],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          svgControls.start("normal");
+          pathControls.start("normal");
+        }
+      },
+      [onMouseLeave, pathControls, svgControls],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={svgControls}
+          initial="normal"
+          variants={PHONE_CALL_VARIANTS}
+        >
+          <motion.path
+            d="M13 2a9 9 0 0 1 9 9"
+            animate={pathControls}
+            custom={2}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="M13 6a5 5 0 0 1 5 5"
+            animate={pathControls}
+            custom={1}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+          <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+PhoneCallIcon.displayName = "PhoneCallIcon";
+
+export { PhoneCallIcon };

--- a/icons/phone-forwarded.tsx
+++ b/icons/phone-forwarded.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Transition, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneForwardedIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneForwardedIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PHONE_FORWARDED_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    scale: 1,
+  },
+  animate: {
+    scale: [1, 1.1, 1],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const ARROW_VARIANTS: Variants = {
+  normal: { x: 0 },
+  animate: { x: [0, 1.3, 1.5, 0] },
+};
+
+const ARROW_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const PhoneForwardedIcon = forwardRef<
+  PhoneForwardedIconHandle,
+  PhoneForwardedIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        animate={controls}
+        initial="normal"
+        variants={PHONE_FORWARDED_VARIANTS}
+      >
+        <motion.g
+          animate={controls}
+          initial="normal"
+          transition={ARROW_TRANSITION}
+          variants={ARROW_VARIANTS}
+        >
+          <path d="M14 6h8" />
+          <path d="m18 2 4 4-4 4" />
+        </motion.g>
+
+        <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+      </motion.svg>
+    </div>
+  );
+});
+
+PhoneForwardedIcon.displayName = "PhoneForwardedIcon";
+
+export { PhoneForwardedIcon };

--- a/icons/phone-incoming.tsx
+++ b/icons/phone-incoming.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Transition, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneIncomingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneIncomingIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PHONE_INCOMING_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    scale: 1,
+  },
+  animate: {
+    scale: [1, 1.1, 1],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const ARROW_VARIANTS: Variants = {
+  normal: { y: 0, x: 0 },
+  animate: { y: [0, 1.6, 0], x: [-1.3, 0] },
+};
+
+const ARROW_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.8,
+};
+
+const PhoneIncomingIcon = forwardRef<
+  PhoneIncomingIconHandle,
+  PhoneIncomingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        animate={controls}
+        initial="normal"
+        variants={PHONE_INCOMING_VARIANTS}
+        style={{ overflow: "visible" }}
+      >
+        <motion.g
+          animate={controls}
+          initial="normal"
+          transition={ARROW_TRANSITION}
+          variants={ARROW_VARIANTS}
+        >
+          <motion.path d="M16 2v6h6" />
+          <motion.path d="m22 2-6 6" />
+        </motion.g>
+        <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+      </motion.svg>
+    </div>
+  );
+});
+
+PhoneIncomingIcon.displayName = "PhoneIncomingIcon";
+
+export { PhoneIncomingIcon };

--- a/icons/phone-missed.tsx
+++ b/icons/phone-missed.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneMissedIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneMissedIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+export interface PhoneMissedIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const PhoneMissedIcon = forwardRef<PhoneMissedIconHandle, PhoneMissedIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="m16 2 6 6"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="m22 2-6 6"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+PhoneMissedIcon.displayName = "PhoneMissedIcon";
+
+export { PhoneMissedIcon };

--- a/icons/phone-off.tsx
+++ b/icons/phone-off.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneOffIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneOffIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const PhoneOffIcon = forwardRef<PhoneOffIconHandle, PhoneOffIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M10.1 13.9a14 14 0 0 0 3.732 2.668 1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2 18 18 0 0 1-12.728-5.272" />
+          <motion.path
+            d="M22 2 2 22"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <path d="M4.76 13.582A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 .244.473" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+PhoneOffIcon.displayName = "PhoneOffIcon";
+
+export { PhoneOffIcon };

--- a/icons/phone-outgoing.tsx
+++ b/icons/phone-outgoing.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Transition, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneOutgoingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneOutgoingIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PHONE_OUTGOING_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    scale: 1,
+  },
+  animate: {
+    scale: [1, 1.1, 1],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const ARROW_VARIANTS: Variants = {
+  normal: { y: 0, x: 0 },
+  animate: { y: [0, -1.8, 0], x: [1.2, 0] },
+};
+
+const ARROW_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.8,
+};
+
+const PhoneOutgoingIcon = forwardRef<
+  PhoneOutgoingIconHandle,
+  PhoneOutgoingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        animate={controls}
+        initial="normal"
+        variants={PHONE_OUTGOING_VARIANTS}
+        style={{ overflow: "visible" }}
+      >
+        <motion.g
+          animate={controls}
+          initial="normal"
+          transition={ARROW_TRANSITION}
+          variants={ARROW_VARIANTS}
+        >
+          <path d="m16 8 6-6" />
+          <path d="M22 8V2h-6" />
+        </motion.g>
+        <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+      </motion.svg>
+    </div>
+  );
+});
+
+PhoneOutgoingIcon.displayName = "PhoneOutgoingIcon";
+
+export { PhoneOutgoingIcon };

--- a/icons/phone.tsx
+++ b/icons/phone.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface PhoneIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PhoneIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PHONE_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    scale: 1,
+  },
+  animate: {
+    rotate: [10, 20, -10, 10, 0],
+    scale: [1, 1.1, 1.2, 1.1, 1],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const PhoneIcon = forwardRef<PhoneIconHandle, PhoneIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      // Only skip default hover when a ref is passed — parent drives animation via the handle.
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          initial="normal"
+          variants={PHONE_VARIANTS}
+        >
+          <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+PhoneIcon.displayName = "PhoneIcon";
+
+export { PhoneIcon };

--- a/icons/plane-landing.tsx
+++ b/icons/plane-landing.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { motion, useAnimation, type Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface PlaneLandingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PlaneLandingIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PLANE_LANDING_VARIANTS: Variants = {
+  normal: {
+    x: 0,
+    y: 0,
+    opacity: 1,
+    scale: 1,
+    rotate: 0,
+  },
+  animate: {
+    x: [-38, 1, 0],
+    y: [-20, 1, 0],
+    opacity: [0, 1, 1],
+    scale: [0.5, 1],
+    rotate: [16, -5, 0],
+    transition: {
+      duration: 1.1,
+      ease: [0.25, 1, 0.5, 1],
+      times: [0, 0.65, 1],
+    },
+  },
+};
+
+const PlaneLandingIcon = forwardRef<
+  PlaneLandingIconHandle,
+  PlaneLandingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = ref != null;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  }, [controls, ref]);
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseEnter?.(e);
+      } else {
+        controls.start("animate");
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseLeave?.(e);
+      } else {
+        controls.start("normal");
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        className="overflow-visible"
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M2 22h20" />
+        <motion.path
+          d="M3.77 10.77 2 9l2-4.5 1.1.55c.55.28.9.84.9 1.45s.35 1.17.9 1.45L8 8.5l3-6 1.05.53a2 2 0 0 1 1.09 1.52l.72 5.4a2 2 0 0 0 1.09 1.52l4.4 2.2c.42.22.78.55 1.01.96l.6 1.03c.49.88-.06 1.98-1.06 2.1l-1.18.15c-.47.06-.95-.02-1.37-.24L4.29 11.15a2 2 0 0 1-.52-.38Z"
+          animate={controls}
+          initial="normal"
+          style={{ originX: 0.5, originY: 0.5 }}
+          variants={PLANE_LANDING_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+PlaneLandingIcon.displayName = "PlaneLandingIcon";
+
+export { PlaneLandingIcon };

--- a/icons/plane-takeoff.tsx
+++ b/icons/plane-takeoff.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface PlaneTakeoffIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PlaneTakeoffIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PLANE_VARIANTS: Variants = {
+  normal: {
+    x: 0,
+    y: 0,
+    opacity: 1,
+    scale: 1,
+    rotate: 0,
+  },
+  animate: {
+    x: [-40, 1, 0],
+    y: [40, -1, 0],
+    opacity: [0, 1],
+    scale: [0.8, 1],
+    rotate: [-15, 5, 0],
+    transition: {
+      duration: 1.1,
+      ease: [0.25, 1, 0.5, 1],
+      times: [0, 0.7, 1],
+    },
+  },
+};
+
+const PlaneTakeoffIcon = forwardRef<
+  PlaneTakeoffIconHandle,
+  PlaneTakeoffIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = ref != null;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  }, [controls, ref]);
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ overflow: "visible" }}
+      >
+        <path d="M2 22h20" />
+        <motion.path
+          d="M6.36 17.4 4 17l-2-4 1.1-.55a2 2 0 0 1 1.8 0l.17.1a2 2 0 0 0 1.8 0L8 12 5 6l.9-.45a2 2 0 0 1 2.09.2l4.02 3a2 2 0 0 0 2.1.2l4.19-2.06a2.41 2.41 0 0 1 1.73-.17L21 7a1.4 1.4 0 0 1 .87 1.99l-.38.76c-.23.46-.6.84-1.07 1.08L7.58 17.2a2 2 0 0 1-1.22.18Z"
+          animate={controls}
+          initial="normal"
+          variants={PLANE_VARIANTS}
+          style={{ originX: 0.5, originY: 0.5 }}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+PlaneTakeoffIcon.displayName = "PlaneTakeoffIcon";
+
+export { PlaneTakeoffIcon };

--- a/icons/projector.tsx
+++ b/icons/projector.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ProjectorIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ProjectorIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PROJECTOR_VARIANTS: Variants = {
+  normal: {
+    scale: 1,
+    y: 0,
+  },
+  animate: {
+    scale: [1, 1.3, 1],
+    y: [0, -1, 0],
+    transition: {
+      duration: 0.8,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 0.5, 1],
+    transition: { duration: 0.3, ease: "linear" },
+  },
+};
+
+const ProjectorIcon = forwardRef<ProjectorIconHandle, ProjectorIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          initial="normal"
+          variants={PROJECTOR_VARIANTS}
+        >
+          <motion.path d="M5 7 3 5" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="M9 6V3" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="m13 7 2-2" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <circle cx="9" cy="13" r="3" />
+          <path d="M11.83 12H20a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h2.17" />
+          <motion.path d="M16 16h2" 
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ProjectorIcon.displayName = "ProjectorIcon";
+
+export { ProjectorIcon };

--- a/icons/receipt-cent.tsx
+++ b/icons/receipt-cent.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptCentIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptCentIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CENT_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const CENT_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptCentIcon = forwardRef<ReceiptCentIconHandle, ReceiptCentIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M12 7v10"
+            animate={controls}
+            initial="normal"
+            variants={CENT_SECONDARY_VARIANTS}
+          />
+          <motion.path
+            d="M14.828 14.829a4 4 0 0 1-5.656 0 4 4 0 0 1 0-5.657 4 4 0 0 1 5.656 0"
+            animate={controls}
+            initial="normal"
+            variants={CENT_MAIN_VARIANTS}
+          />
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptCentIcon.displayName = "ReceiptCentIcon";
+
+export { ReceiptCentIcon };

--- a/icons/receipt-euro.tsx
+++ b/icons/receipt-euro.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptEuroIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptEuroIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const EURO_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const EURO_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptEuroIcon = forwardRef<ReceiptEuroIconHandle, ReceiptEuroIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M15.828 14.829a4 4 0 0 1-5.656 0 4 4 0 0 1 0-5.657 4 4 0 0 1 5.656 0"
+            animate={controls}
+            initial="normal"
+            variants={EURO_MAIN_VARIANTS}
+          />
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+          <motion.path
+            d="M8 12h5"
+            animate={controls}
+            initial="normal"
+            variants={EURO_SECONDARY_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptEuroIcon.displayName = "ReceiptEuroIcon";
+
+export { ReceiptEuroIcon };

--- a/icons/receipt-indian-rupee.tsx
+++ b/icons/receipt-indian-rupee.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptIndianRupeeIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptIndianRupeeIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const INDIAN_RUPEE_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const INDIAN_RUPEE_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptIndianRupeeIcon = forwardRef<
+  ReceiptIndianRupeeIconHandle,
+  ReceiptIndianRupeeIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 11h8"
+          animate={controls}
+          initial="normal"
+          variants={INDIAN_RUPEE_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M8 7h8"
+          animate={controls}
+          initial="normal"
+          variants={INDIAN_RUPEE_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M9 7a4 4 0 0 1 0 8H8l3 2"
+          animate={controls}
+          initial="normal"
+          variants={INDIAN_RUPEE_MAIN_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptIndianRupeeIcon.displayName = "ReceiptIndianRupeeIcon";
+
+export { ReceiptIndianRupeeIcon };

--- a/icons/receipt-japanese-yen.tsx
+++ b/icons/receipt-japanese-yen.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptJapaneseYenIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptJapaneseYenIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const JAPANESE_YEN_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const JAPANESE_YEN_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptJapaneseYenIcon = forwardRef<
+  ReceiptJapaneseYenIconHandle,
+  ReceiptJapaneseYenIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="m12 10 3-3"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_MAIN_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M9 11h6"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M9 15h6"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="m9 7 3 3v7"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_MAIN_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptJapaneseYenIcon.displayName = "ReceiptJapaneseYenIcon";
+
+export { ReceiptJapaneseYenIcon };

--- a/icons/receipt-pound-sterling.tsx
+++ b/icons/receipt-pound-sterling.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptPoundSterlingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+const POUND_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const POUND_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+interface ReceiptPoundSterlingIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ReceiptPoundSterlingIcon = forwardRef<
+  ReceiptPoundSterlingIconHandle,
+  ReceiptPoundSterlingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M10 17V9.5a1 1 0 0 1 5 0"
+          animate={controls}
+          initial="normal"
+          variants={POUND_MAIN_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 13h5"
+          animate={controls}
+          initial="normal"
+          variants={POUND_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M8 17h7"
+          animate={controls}
+          initial="normal"
+          variants={POUND_SECONDARY_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptPoundSterlingIcon.displayName = "ReceiptPoundSterlingIcon";
+
+export { ReceiptPoundSterlingIcon };

--- a/icons/receipt-russian-ruble.tsx
+++ b/icons/receipt-russian-ruble.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptRussianRubleIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptRussianRubleIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const RUSSIAN_RUBLE_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const RUSSIAN_RUBLE_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptRussianRubleIcon = forwardRef<
+  ReceiptRussianRubleIconHandle,
+  ReceiptRussianRubleIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 11h5a2 2 0 0 0 0-4h-3v10"
+          animate={controls}
+          initial="normal"
+          variants={RUSSIAN_RUBLE_MAIN_VARIANTS}
+        />
+        <motion.path
+          d="M8 15h5"
+          animate={controls}
+          initial="normal"
+          variants={RUSSIAN_RUBLE_SECONDARY_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptRussianRubleIcon.displayName = "ReceiptRussianRubleIcon";
+
+export { ReceiptRussianRubleIcon };

--- a/icons/receipt-swiss-franc.tsx
+++ b/icons/receipt-swiss-franc.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptSwissFrancIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptSwissFrancIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const FRANC_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const FRANC_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptSwissFrancIcon = forwardRef<
+  ReceiptSwissFrancIconHandle,
+  ReceiptSwissFrancIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M10 11h4"
+          animate={controls}
+          initial="normal"
+          variants={FRANC_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M10 17V7h5"
+          animate={controls}
+          initial="normal"
+          variants={FRANC_MAIN_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 15h5"
+          animate={controls}
+          initial="normal"
+          variants={FRANC_SECONDARY_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptSwissFrancIcon.displayName = "ReceiptSwissFrancIcon";
+
+export { ReceiptSwissFrancIcon };

--- a/icons/receipt-text.tsx
+++ b/icons/receipt-text.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptTextIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptTextIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const LINES_CONTAINER_VARIANTS: Variants = {
+  visible: {
+    transition: { staggerChildren: 0.1, delayChildren: 0 },
+  },
+  hidden: {
+    transition: { staggerChildren: 0.06, staggerDirection: -1 },
+  },
+};
+
+const LINE_VARIANTS: Variants = {
+  visible: {
+    pathLength: 1,
+    opacity: 1,
+    transition: { duration: 0.35, ease: "linear" },
+  },
+  hidden: {
+    pathLength: 0,
+    opacity: 1,
+    transition: { duration: 0.2, ease: "linear" },
+  },
+};
+
+const ReceiptTextIcon = forwardRef<ReceiptTextIconHandle, ReceiptTextIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    const replayLines = useCallback(async () => {
+      await controls.start("hidden");
+      await controls.start("visible");
+    }, [controls]);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: () => replayLines(),
+        stopAnimation: () => controls.start("visible"),
+      };
+    }, [controls, ref, replayLines]);
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          await replayLines();
+        }
+      },
+      [onMouseEnter, replayLines],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("visible");
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+          <motion.g
+            animate={controls}
+            initial="visible"
+            variants={LINES_CONTAINER_VARIANTS}
+          >
+            <motion.path d="M8 8H14" variants={LINE_VARIANTS} />
+            <motion.path d="M8 12H16" variants={LINE_VARIANTS} />
+            <motion.path d="M8 16H13" variants={LINE_VARIANTS} />
+          </motion.g>
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptTextIcon.displayName = "ReceiptTextIcon";
+
+export { ReceiptTextIcon };

--- a/icons/receipt-turkish-lira.tsx
+++ b/icons/receipt-turkish-lira.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptTurkishLiraIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptTurkishLiraIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const LIRA_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const LIRA_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptTurkishLiraIcon = forwardRef<
+  ReceiptTurkishLiraIconHandle,
+  ReceiptTurkishLiraIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M10 7v10a5 5 0 0 0 5-5"
+          animate={controls}
+          initial="normal"
+          variants={LIRA_MAIN_VARIANTS}
+        />
+        <motion.path
+          d="m14 8-6 3"
+          animate={controls}
+          initial="normal"
+          variants={LIRA_SECONDARY_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptTurkishLiraIcon.displayName = "ReceiptTurkishLiraIcon";
+
+export { ReceiptTurkishLiraIcon };

--- a/icons/receipt.tsx
+++ b/icons/receipt.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DOLLAR_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const DOLLAR_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptIcon = forwardRef<ReceiptIconHandle, ReceiptIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M12 17V7"
+            animate={controls}
+            initial="normal"
+            variants={DOLLAR_SECONDARY_VARIANTS}
+          />
+          <motion.path
+            d="M16 8h-6a2 2 0 0 0 0 4h4a2 2 0 0 1 0 4H8"
+            animate={controls}
+            initial="normal"
+            variants={DOLLAR_MAIN_VARIANTS}
+          />
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptIcon.displayName = "ReceiptIcon";
+
+export { ReceiptIcon };

--- a/icons/recycle.tsx
+++ b/icons/recycle.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface RecycleIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface RecycleIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal :{ pathLength: 1 },
+  animate:{
+      pathLength: [0, 1],
+      transition: { duration: 0.4, ease: "linear" },
+  },
+}
+
+const RecycleIcon = forwardRef<RecycleIconHandle, RecycleIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(
+      ref,
+      () => {
+        isControlledRef.current = ref != null;
+        return {
+          startAnimation: () => controls.start("animate"),
+          stopAnimation: () => controls.start("normal"),
+        };
+      },
+      [controls, ref],
+    );
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          initial="normal"
+        >
+          <motion.path d="M7 19H4.815a1.83 1.83 0 0 1-1.57-.881 1.785 1.785 0 0 1-.004-1.784L7.196 9.5" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="M11 19h8.203a1.83 1.83 0 0 0 1.556-.89 1.784 1.784 0 0 0 0-1.775l-1.226-2.12" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="m14 16-3 3 3 3" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="M8.293 13.596 7.196 9.5 3.1 10.598" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="m9.344 5.811 1.093-1.892A1.83 1.83 0 0 1 11.985 3a1.784 1.784 0 0 1 1.546.888l3.943 6.843" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+          <motion.path d="m13.378 9.633 4.096 1.098 1.097-4.096" 
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+RecycleIcon.displayName = "RecycleIcon";
+
+export { RecycleIcon };

--- a/icons/router.tsx
+++ b/icons/router.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface RouterIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface RouterIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    transition: {
+      duration: 0.4,
+    },
+  },
+  fadeOut: {
+    opacity: 0,
+    transition: { duration: 0.3 },
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      type: "spring",
+      stiffness: 300,
+      damping: 20,
+      delay: i * 0.1,
+    },
+  }),
+};
+
+const RouterIcon = forwardRef<RouterIconHandle, RouterIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const pathControls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    const runPathIntro = useCallback(async () => {
+      await pathControls.start("fadeOut");
+      pathControls.start("fadeIn");
+    }, [pathControls]);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: async () => {
+          await runPathIntro();
+        },
+        stopAnimation: () => {
+          pathControls.start("normal");
+        },
+      };
+    }, [pathControls, ref, runPathIntro]);
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          await runPathIntro();
+        }
+      },
+      [onMouseEnter, runPathIntro],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          pathControls.start("normal");
+        }
+      },
+      [onMouseLeave, pathControls],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect width="20" height="8" x="2" y="14" rx="2" />
+          <path d="M6.01 18H6" />
+          <path d="M10.01 18H10" />
+          <path d="M15 10v4" />
+          <motion.path
+            d="M17.84 7.17a4 4 0 0 0-5.66 0"
+            animate={pathControls}
+            custom={1}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="M20.66 4.34a8 8 0 0 0-11.31 0"
+            animate={pathControls}
+            custom={2}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+RouterIcon.displayName = "RouterIcon";
+
+export { RouterIcon };

--- a/icons/satellite-dish.tsx
+++ b/icons/satellite-dish.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface SatelliteDishIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SatelliteDishIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SATELLITE_DISH_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+    rotate: 0,
+  },
+  animate: {
+    y: [0, 1, 2, 0],
+    rotate: [0, -50, 0],
+    transition: {
+      duration: 1.5,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    transition: {
+      duration: 1.1,
+    },
+  },
+  fadeOut: {
+    opacity: 0,
+    transition: { duration: 1.1 },
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      type: "spring",
+      stiffness: 300,
+      damping: 20,
+      delay: i * 0.1,
+    },
+  }),
+};
+
+const SatelliteDishIcon = forwardRef<
+  SatelliteDishIconHandle,
+  SatelliteDishIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const svgControls = useAnimation();
+  const pathControls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  const runPathIntro = useCallback(async () => {
+    await pathControls.start("fadeOut");
+    pathControls.start("fadeIn");
+  }, [pathControls]);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = ref != null;
+    return {
+      startAnimation: async () => {
+        void svgControls.start("animate");
+        await runPathIntro();
+      },
+      stopAnimation: () => {
+        svgControls.start("normal");
+        pathControls.start("normal");
+      },
+    };
+  }, [pathControls, ref, runPathIntro, svgControls]);
+
+  const handleMouseEnter = useCallback(
+    async (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseEnter?.(e);
+      } else {
+        void svgControls.start("animate");
+        await runPathIntro();
+      }
+    },
+    [onMouseEnter, runPathIntro, svgControls],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseLeave?.(e);
+      } else {
+        svgControls.start("normal");
+        pathControls.start("normal");
+      }
+    },
+    [onMouseLeave, pathControls, svgControls],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        animate={svgControls}
+        initial="normal"
+        variants={SATELLITE_DISH_VARIANTS}
+      >
+        <path d="M4 10a7.31 7.31 0 0 0 10 10Z" />
+        <path d="m9 15 3-3" />
+        <motion.path
+          d="M17 13a6 6 0 0 0-6-6"
+          animate={pathControls}
+          custom={1}
+          initial={{ opacity: 1 }}
+          variants={PATH_VARIANTS}
+        />
+        <motion.path
+          d="M21 13A10 10 0 0 0 11 3"
+          animate={pathControls}
+          custom={2}
+          initial={{ opacity: 1 }}
+          variants={PATH_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+SatelliteDishIcon.displayName = "SatelliteDishIcon";
+
+export { SatelliteDishIcon };

--- a/icons/server-cog.tsx
+++ b/icons/server-cog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ServerCogIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ServerCogIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const COG_VARIANTS: Variants = {
+  normal: { rotate: 0 },
+  animate: { rotate: 180 },
+};
+
+const ServerCogIcon = forwardRef<ServerCogIconHandle, ServerCogIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+        >
+          <motion.g
+            animate={controls}
+            transition={{ type: "spring", stiffness: 50, damping: 10 }}
+            variants={COG_VARIANTS}
+          >
+            <path d="m10.852 14.772-.383.923" />
+            <path d="M13.148 14.772a3 3 0 1 0-2.296-5.544l-.383-.923" />
+            <path d="m13.148 9.228.383-.923" />
+            <path d="m13.53 15.696-.382-.924a3 3 0 1 1-2.296-5.544" />
+            <path d="m14.772 10.852.923-.383" />
+            <path d="m14.772 13.148.923.383" />
+            <path d="m9.228 10.852-.923-.383" />
+            <path d="m9.228 13.148-.923.383" />
+          </motion.g>
+
+          <path d="M4.5 10H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-.5" />
+          <path d="M4.5 14H4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2h-.5" />
+          <path d="M6 18h.01" />
+          <path d="M6 6h.01" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ServerCogIcon.displayName = "ServerCogIcon";
+
+export { ServerCogIcon };

--- a/icons/server-crash.tsx
+++ b/icons/server-crash.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ServerCrashIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ServerCrashIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const ServerCrashIcon = forwardRef<ServerCrashIconHandle, ServerCrashIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+        >
+          <path d="M6 10H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2" />
+          <path d="M6 14H4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2h-2" />
+          <path d="M6 6h.01" />
+          <path d="M6 18h.01" />
+          <motion.path
+            d="m13 6-4 6h6l-4 6"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ServerCrashIcon.displayName = "ServerCrashIcon";
+
+export { ServerCrashIcon };

--- a/icons/server-off.tsx
+++ b/icons/server-off.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ServerOffIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ServerOffIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const ServerOffIcon = forwardRef<ServerOffIconHandle, ServerOffIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+        >
+          <motion.path
+            d="M7 2h13a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-5"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="M10 10 2.5 2.5C2 2 2 2.5 2 5v3a2 2 0 0 0 2 2h6z"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="M22 17v-1a2 2 0 0 0-2-2h-1"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="M4 14a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h16.5l1-.5.5.5-8-8H4z"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="M6 18h.01"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="m2 2 20 20"
+            animate={controls}
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ServerOffIcon.displayName = "ServerOffIcon";
+
+export { ServerOffIcon };

--- a/icons/server.tsx
+++ b/icons/server.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ServerIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ServerIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const TOP_RECT_VARIANTS: Variants = {
+  normal: { translateX: 0, translateY: 0 },
+  animate: {
+    translateX: [0, 0, 0, 0],
+    translateY: [0, 11, 11, 0],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+      repeat: Number.POSITIVE_INFINITY,
+      times: [0, 0.35, 0.65, 1],
+    },
+  },
+};
+
+const BOTTOM_RECT_VARIANTS: Variants = {
+  normal: { translateX: 0, translateY: 0 },
+  animate: {
+    translateX: [0, 0, 0, 0],
+    translateY: [0, -11, -11, 0],
+    transition: {
+      duration: 0.9,
+      ease: "easeInOut",
+      repeat: Number.POSITIVE_INFINITY,
+      times: [0, 0.35, 0.65, 1],
+    },
+  },
+};
+
+const ServerIcon = forwardRef<ServerIconHandle, ServerIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    }, [controls, ref]);
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          className="overflow-visible"
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.g
+            animate={controls}
+            initial="normal"
+            variants={TOP_RECT_VARIANTS}
+          >
+            <rect height="8" rx="2" ry="2" width="20" x="2" y="2" />
+            <line x1="6" x2="10" y1="6" y2="6" />
+          </motion.g>
+          <motion.g
+            animate={controls}
+            initial="normal"
+            variants={BOTTOM_RECT_VARIANTS}
+          >
+            <rect height="8" rx="2" ry="2" width="20" x="2" y="14" />
+            <line x1="6" x2="10" y1="18" y2="18" />
+          </motion.g>
+        </svg>
+      </div>
+    );
+  },
+);
+
+ServerIcon.displayName = "ServerIcon";
+
+export { ServerIcon };

--- a/icons/ship-wheel.tsx
+++ b/icons/ship-wheel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ShipWheelIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ShipWheelIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SHIP_WHEEL_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    transition: { type: "spring", stiffness: 50, damping: 10 },
+  },
+  animate: {
+    rotate: 180,
+    transition: { type: "spring", stiffness: 50, damping: 10 },
+  },
+};
+
+const ShipWheelIcon = forwardRef<ShipWheelIconHandle, ShipWheelIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          initial="normal"
+          variants={SHIP_WHEEL_VARIANTS}
+        >
+          <circle cx="12" cy="12" r="8" />
+          <path d="M12 2v7.5" />
+          <path d="m19 5-5.23 5.23" />
+          <path d="M22 12h-7.5" />
+          <path d="m19 19-5.23-5.23" />
+          <path d="M12 14.5V22" />
+          <path d="M10.23 13.77 5 19" />
+          <path d="M9.5 12H2" />
+          <path d="M10.23 10.23 5 5" />
+          <circle cx="12" cy="12" r="2.5" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ShipWheelIcon.displayName = "ShipWheelIcon";
+
+export { ShipWheelIcon };

--- a/icons/spotlight.tsx
+++ b/icons/spotlight.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface SpotlightIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SpotlightIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SPOTLIGHT_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+  },
+  animate: {
+    rotate: [0, -10, 10, -5, 5, 0],
+    transition: {
+      duration: 1.2,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    transition: {
+      duration: 1.1,
+    },
+  },
+  fadeOut: {
+    opacity: 0,
+    transition: { duration: 1.1 },
+  },
+  fadeIn: (i: number) => ({
+    opacity: 1,
+    transition: {
+      type: "spring",
+      stiffness: 300,
+      damping: 20,
+      delay: i * 0.1,
+    },
+  }),
+};
+
+const SpotlightIcon = forwardRef<SpotlightIconHandle, SpotlightIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const beamControls = useAnimation();
+    const pathControls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    const runPathIntro = useCallback(async () => {
+      await pathControls.start("fadeOut");
+      pathControls.start("fadeIn");
+    }, [pathControls]);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: async () => {
+          void beamControls.start("animate");
+          await runPathIntro();
+        },
+        stopAnimation: () => {
+          beamControls.start("normal");
+          pathControls.start("normal");
+        },
+      };
+    }, [beamControls, pathControls, ref, runPathIntro]);
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          void beamControls.start("animate");
+          await runPathIntro();
+        }
+      },
+      [beamControls, onMouseEnter, runPathIntro],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          beamControls.start("normal");
+          pathControls.start("normal");
+        }
+      },
+      [beamControls, onMouseLeave, pathControls],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M15.295 19.562 16 22"
+            animate={pathControls}
+            custom={0}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="m17 16 3.758 2.098"
+            animate={pathControls}
+            custom={1}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            d="m19 12.5 3.026-.598"
+            animate={pathControls}
+            custom={2}
+            initial={{ opacity: 1 }}
+            variants={PATH_VARIANTS}
+          />
+
+          <motion.path
+            d="M7.61 6.3a3 3 0 0 0-3.92 1.3l-1.38 2.79a3 3 0 0 0 1.3 3.91l6.89 3.597a1 1 0 0 0 1.342-.447l3.106-6.211a1 1 0 0 0-.447-1.341z"
+            animate={beamControls}
+            initial="normal"
+            variants={SPOTLIGHT_VARIANTS}
+          />
+          <motion.path d="M8 9V2" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+SpotlightIcon.displayName = "SpotlightIcon";
+
+export { SpotlightIcon };

--- a/icons/switch-camera.tsx
+++ b/icons/switch-camera.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface SwitchCameraIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SwitchCameraIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const SwitchCameraIcon = forwardRef<
+  SwitchCameraIconHandle,
+  SwitchCameraIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        animate={controls}
+      >
+        <motion.path
+          d="M11 19H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h5"
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+        />
+        <motion.path
+          d="M13 5h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-5"
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+        />
+        <circle cx="12" cy="12" r="3" />
+        <motion.path
+          d="m18 22-3-3 3-3"
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+        />
+        <motion.path
+          d="m6 2 3 3-3 3"
+          animate={controls}
+          initial="normal"
+          variants={PATH_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+SwitchCameraIcon.displayName = "SwitchCameraIcon";
+
+export { SwitchCameraIcon };

--- a/icons/tree-deciduous.tsx
+++ b/icons/tree-deciduous.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface TreeDeciduousIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface TreeDeciduousIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const TreeDeciduousIcon = forwardRef<
+  TreeDeciduousIconHandle,
+  TreeDeciduousIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        animate={controls}
+      >
+        <motion.path
+          d="M8 19a4 4 0 0 1-2.24-7.32A3.5 3.5 0 0 1 9 6.03V6a3 3 0 1 1 6 0v.04a3.5 3.5 0 0 1 3.24 5.65A4 4 0 0 1 16 19Z"
+          animate={controls}
+          initial={{ pathLength: 1 }}
+          variants={{
+            normal: { pathLength: 1 },
+            animate: {
+              pathLength: [0, 1],
+              transition: { duration: 0.4, ease: "linear" },
+            },
+          }}
+        />
+        <path d="M12 19v3" />
+      </motion.svg>
+    </div>
+  );
+});
+
+TreeDeciduousIcon.displayName = "TreeDeciduousIcon";
+
+export { TreeDeciduousIcon };

--- a/icons/tree-pine.tsx
+++ b/icons/tree-pine.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface TreePineIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface TreePineIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SVG_VARIANTS: Variants = {
+  normal: { rotate: 0 },
+  animate: { rotate: [0, -10, 10, -10, 0] },
+};
+
+const TreePineIcon = forwardRef<TreePineIconHandle, TreePineIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          animate={controls}
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          transition={{
+            duration: 0.5,
+            ease: "easeInOut",
+          }}
+          variants={SVG_VARIANTS}
+        >
+          <path d="m17 14 3 3.3a1 1 0 0 1-.7 1.7H4.7a1 1 0 0 1-.7-1.7L7 14h-.3a1 1 0 0 1-.7-1.7L9 9h-.2A1 1 0 0 1 8 7.3L12 3l4 4.3a1 1 0 0 1-.8 1.7H15l3 3.3a1 1 0 0 1-.7 1.7H17Z" />
+          <path d="M12 22v-3" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+TreePineIcon.displayName = "TreePineIcon";
+
+export { TreePineIcon };

--- a/icons/utility-pole.tsx
+++ b/icons/utility-pole.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface UtilityPoleIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+const UTILITY_POLE_VARIANTS: Variants = {
+  normal: {
+    rotateY: 0,
+    scale: 1,
+  },
+  animate: {
+    rotateY: 180,
+    scale: [1, 1.2, 1.1, 1],
+    transition: {
+      rotateX: {
+        duration: 0.8,
+        ease: "easeInOut",
+      },
+      scale: {
+        duration: 0.6,
+        ease: "easeInOut",
+      },
+    },
+  },
+};
+
+interface UtilityPoleIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const UtilityPoleIcon = forwardRef<UtilityPoleIconHandle, UtilityPoleIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          animate={controls}
+          variants={UTILITY_POLE_VARIANTS}
+        >
+          <path d="M12 2v20" />
+          <path d="M2 5h20" />
+          <path d="M3 3v2" />
+          <path d="M7 3v2" />
+          <path d="M17 3v2" />
+          <path d="M21 3v2" />
+          <path d="m19 5-7 7-7-7" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+UtilityPoleIcon.displayName = "UtilityPoleIcon";
+
+export { UtilityPoleIcon };

--- a/icons/waves-arrow-down.tsx
+++ b/icons/waves-arrow-down.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface WavesArrowDownIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface WavesArrowDownIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ARROW_VARIANTS: Variants = {
+  normal: { y: 0 },
+  animate: {
+    y: 2,
+    transition: {
+      type: "spring",
+      stiffness: 200,
+      damping: 10,
+      mass: 1,
+    },
+  },
+};
+
+const WavesArrowDownIcon = forwardRef<
+  WavesArrowDownIconHandle,
+  WavesArrowDownIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.g animate={controls} initial="normal" variants={ARROW_VARIANTS}>
+          <path d="M12 10L12 2" />
+          <path d="M16 6L12 10L8 6" />
+        </motion.g>
+        <motion.path
+          d="M2 15C2.6 15.5 3.2 16 4.5 16C7 16 7 14 9.5 14C12.1 14 11.9 16 14.5 16C17 16 17 14 19.5 14C20.8 14 21.4 14.5 22 15"
+          animate={controls}
+          initial={{ pathLength: 1 }}
+          variants={{
+            normal: { pathLength: 1 },
+            animate: {
+              pathLength: [0, 1],
+              transition: { duration: 0.4, ease: "linear" },
+            },
+          }}
+        />
+        <motion.path
+          d="M2 21C2.6 21.5 3.2 22 4.5 22C7 22 7 20 9.5 20C12.1 20 11.9 22 14.5 22C17 22 17 20 19.5 20C20.8 20 21.4 20.5 22 21"
+          animate={controls}
+          initial={{ pathLength: 1 }}
+          variants={{
+            normal: { pathLength: 1 },
+            animate: {
+              pathLength: [0, 1],
+              transition: { duration: 0.4, ease: "linear" },
+            },
+          }}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+WavesArrowDownIcon.displayName = "WavesArrowDownIcon";
+
+export { WavesArrowDownIcon };

--- a/icons/waves-arrow-up.tsx
+++ b/icons/waves-arrow-up.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+export interface WavesArrowUpIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface WavesArrowUpIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ARROW_VARIANTS: Variants = {
+  normal: { y: 0 },
+  animate: {
+    y: -1,
+    transition: {
+      type: "spring",
+      stiffness: 200,
+      damping: 10,
+      mass: 1,
+    },
+  },
+};
+
+const WavesArrowUpIcon = forwardRef<
+  WavesArrowUpIconHandle,
+  WavesArrowUpIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ overflow: "visible" }}
+      >
+        <motion.g animate={controls} variants={ARROW_VARIANTS}>
+          <path d="M12 2v8" />
+          <path d="m8 6 4-4 4 4" />
+        </motion.g>
+        <motion.path
+          d="M2 15c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"
+          animate={controls}
+          initial={{ pathLength: 1 }}
+          variants={{
+            normal: { pathLength: 1 },
+            animate: {
+              pathLength: [0, 1],
+              transition: { duration: 0.4, ease: "linear" },
+            },
+          }}
+        />
+        <motion.path
+          d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"
+          animate={controls}
+          initial={{ pathLength: 1 }}
+          variants={{
+            normal: { pathLength: 1 },
+            animate: {
+              pathLength: [0, 1],
+              transition: { duration: 0.4, ease: "linear" },
+            },
+          }}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+WavesArrowUpIcon.displayName = "WavesArrowUpIcon";
+
+export { WavesArrowUpIcon };

--- a/icons/wifi-cog.tsx
+++ b/icons/wifi-cog.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface WifiCogIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface WifiCogIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const COG_VARIANTS: Variants = {
+  normal: { rotate: 0 },
+  animate: { rotate: 180 },
+};
+
+const WifiCogIcon = forwardRef<WifiCogIconHandle, WifiCogIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M2 7.82a15 15 0 0 1 20 0" />
+          <path d="M5 11.858a10 10 0 0 1 11.5-1.785" />
+          <path d="M8.5 15.429a5 5 0 0 1 2.413-1.31" />
+          <motion.g
+            animate={controls}
+            transition={{ type: "spring", stiffness: 50, damping: 10 }}
+            variants={COG_VARIANTS}
+          >
+            <path d="m14.305 19.53.923-.382" />
+            <path d="m15.228 16.852-.923-.383" />
+            <path d="m16.852 15.228-.383-.923" />
+            <path d="m16.852 20.772-.383.924" />
+            <path d="m19.148 15.228.383-.923" />
+            <path d="m19.53 21.696-.382-.924" />
+            <path d="m20.772 16.852.924-.383" />
+            <path d="m20.772 19.148.924.383" />
+            <circle cx="18" cy="18" r="3" />
+          </motion.g>
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+WifiCogIcon.displayName = "WifiCogIcon";
+
+export { WifiCogIcon };

--- a/icons/wifi-pen.tsx
+++ b/icons/wifi-pen.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface WifiPenIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface WifiPenIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PEN_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+    x: 0,
+    y: 0,
+  },
+  animate: {
+    rotate: [-0.3, 0.2, -0.4],
+    x: [0, -0.5, 1, 0],
+    y: [0, 1, -0.5, 0],
+    transition: {
+      duration: 0.5,
+      repeat: 1,
+      ease: "easeInOut",
+    },
+  },
+};
+
+const WifiPenIcon = forwardRef<WifiPenIconHandle, WifiPenIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M2 8.82a15 15 0 0 1 20 0" />
+          <motion.path
+            d="M21.378 16.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z"
+            animate={controls}
+            initial="normal"
+            variants={PEN_VARIANTS}
+          />
+          <path d="M5 12.859a10 10 0 0 1 10.5-2.222" />
+          <path d="M8.5 16.429a5 5 0 0 1 3-1.406" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+WifiPenIcon.displayName = "WifiPenIcon";
+
+export { WifiPenIcon };

--- a/icons/wifi-sync.tsx
+++ b/icons/wifi-sync.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { motion, Transition, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface WifiSyncIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface WifiSyncIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SYNC_VARIANTS: Variants = {
+  normal: { rotate: 0 },
+  animate: { rotate: -360 },
+};
+
+const SYNC_TRANSITION: Transition = {
+  duration: 1.2,
+  ease: "easeInOut",
+};
+
+const WifiSyncIcon = forwardRef<WifiSyncIconHandle, WifiSyncIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M2 8.82a15 15 0 0 1 20 0" />
+          <path d="M5 12.86a10 10 0 0 1 3-2.032" />
+          <path d="M8.5 16.429h.01" />
+          <motion.g
+            animate={controls}
+            initial="normal"
+            transition={SYNC_TRANSITION}
+            variants={SYNC_VARIANTS}
+          >
+            <path d="M11.965 10.105v4L13.5 12.5a5 5 0 0 1 8 1.5" />
+            <path d="M11.965 14.105h4" />
+            <path d="M17.965 18.105h4L20.43 19.71a5 5 0 0 1-8-1.5" />
+            <path d="M21.965 22.105v-4" />
+          </motion.g>
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+WifiSyncIcon.displayName = "WifiSyncIcon";
+
+export { WifiSyncIcon };


### PR DESCRIPTION
This PR introduces 50 new animated icons based on the Lucide icon set. Each icon has been implemented following the existing project structure and includes interaction-based animations such as hover, click, and appearance transitions. The goal was to ensure that all icons remain lightweight, reusable, and fully compatible with modern frontend environments like React.

All icons are designed to align consistently with the project’s standards in terms of structure, animation behavior, and usability. I have also verified them for consistency to ensure a smooth developer experience when integrating them into applications.

This PR addresses #241 and includes the following icons:

1. leaf 
2. leafy-green
3. recycle
4. tree-pine
5. waves-arrow-up
6. waves-arrow-down
7. tree-deciduous
8. utility-pole
9. flower
10. flower-2
11. alarm-clock-check
12. alarm-clock-plus
13. alarm-clock-minus
14. alarm-smoke
15. antenna
16. phone
17. phone-call
18. phone-forwarded
19. phone-incoming
20. phone-missed
21. phone-off
22. phone-outgoing
23. router
24. satellite-dish
25. projector
26. spotlight
27. switch-camera
28. wifi-cog
29. wifi-sync
30. wifi-pen
31. server
32. server-cog
33. server-crash
34. server-off
35. gamepad-directional
36. cigarette
37. cigarette-off
38. receipt
39. receipt-cent
40. receipt-euro
41. receipt-indian-rupee
42. receipt-japanese-yen
43. receipt-pound-sterling
44. receipt-russian-ruble
45. receipt-swiss-franc
46. receipt-text
47. receipt-turkish-lira
48. ship-wheel
49. plane-takeoff
50. plane-landing

Please feel free to review and share any feedback or suggestions. If any icons require refinement or if you would like additional icons to be included, I would be happy to iterate and contribute further.

Thank you 🫡
