### PR TITLE
feat(icons): add animated lucide icons (batch 5)

### DIFF
--- a/icons/index.ts
+++ b/icons/index.ts
@@ -402,6 +402,16 @@ import { HandMetalIcon } from "./hand-metal";
 import { HeartHandshakeIcon } from "./heart-handshake";
 import { HeartPulseIcon } from "./heart-pulse";
 import { TruckIcon } from "./truck";
+import { ReceiptIcon } from "./receipt";
+import { ReceiptCentIcon } from "./receipt-cent";
+import { ReceiptEuroIcon } from "./receipt-euro";
+import { ReceiptIndianRupeeIcon } from "./receipt-indian-rupee";
+import { ReceiptJapaneseYenIcon } from "./receipt-japanese-yen";
+import { ReceiptPoundSterlingIcon } from "./receipt-pound-sterling";
+import { ReceiptRussianRubleIcon } from "./receipt-russian-ruble";
+import { ReceiptSwissFrancIcon } from "./receipt-swiss-franc";
+import { ReceiptTextIcon } from "./receipt-text";
+import { ReceiptTurkishLiraIcon } from "./receipt-turkish-lira";
 
 type IconListItem = {
   name: string;
@@ -410,6 +420,57 @@ type IconListItem = {
 };
 
 const ICON_LIST: IconListItem[] = [
+  
+  {
+    name: "receipt",
+    icon: ReceiptIcon,
+    keywords: ["receipt", "invoice", "receipt icon"],
+  },
+  {
+    name: "receipt-cent",
+    icon: ReceiptCentIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "cent", "currency"],
+  },
+  {
+    name: "receipt-euro",
+    icon: ReceiptEuroIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "euro", ],
+  },
+  {
+    name: "receipt-indian-rupee",
+    icon: ReceiptIndianRupeeIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "indian rupee", "rupee"],
+  },
+  {
+    name: "receipt-japanese-yen",
+    icon: ReceiptJapaneseYenIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "japanese yen", "yen"],
+  },
+  {
+    name: "receipt-pound-sterling",
+    icon: ReceiptPoundSterlingIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "pound sterling", "sterling"],
+  },
+  {
+    name: "receipt-russian-ruble",
+    icon: ReceiptRussianRubleIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "russian ruble", "ruble"],
+  },
+  {
+    name: "receipt-swiss-franc",
+    icon: ReceiptSwissFrancIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "swiss franc", "franc"],
+  },
+  {
+    name: "receipt-text",
+    icon: ReceiptTextIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "text"],
+  },
+  {
+    name: "receipt-turkish-lira",
+    icon: ReceiptTurkishLiraIcon,
+    keywords: ["receipt", "invoice", "receipt icon", "turkish lira", "lira"],
+  },
   {
     name: "layout-grid",
     icon: LayoutGridIcon,

--- a/icons/receipt-cent.tsx
+++ b/icons/receipt-cent.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptCentIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptCentIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CENT_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const CENT_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptCentIcon = forwardRef<ReceiptCentIconHandle, ReceiptCentIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M12 7v10"
+            animate={controls}
+            initial="normal"
+            variants={CENT_SECONDARY_VARIANTS}
+          />
+          <motion.path
+            d="M14.828 14.829a4 4 0 0 1-5.656 0 4 4 0 0 1 0-5.657 4 4 0 0 1 5.656 0"
+            animate={controls}
+            initial="normal"
+            variants={CENT_MAIN_VARIANTS}
+          />
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptCentIcon.displayName = "ReceiptCentIcon";
+
+export { ReceiptCentIcon };

--- a/icons/receipt-euro.tsx
+++ b/icons/receipt-euro.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptEuroIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptEuroIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const EURO_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const EURO_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptEuroIcon = forwardRef<ReceiptEuroIconHandle, ReceiptEuroIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M15.828 14.829a4 4 0 0 1-5.656 0 4 4 0 0 1 0-5.657 4 4 0 0 1 5.656 0"
+            animate={controls}
+            initial="normal"
+            variants={EURO_MAIN_VARIANTS}
+          />
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+          <motion.path
+            d="M8 12h5"
+            animate={controls}
+            initial="normal"
+            variants={EURO_SECONDARY_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptEuroIcon.displayName = "ReceiptEuroIcon";
+
+export { ReceiptEuroIcon };

--- a/icons/receipt-indian-rupee.tsx
+++ b/icons/receipt-indian-rupee.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptIndianRupeeIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptIndianRupeeIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const INDIAN_RUPEE_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const INDIAN_RUPEE_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptIndianRupeeIcon = forwardRef<
+  ReceiptIndianRupeeIconHandle,
+  ReceiptIndianRupeeIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 11h8"
+          animate={controls}
+          initial="normal"
+          variants={INDIAN_RUPEE_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M8 7h8"
+          animate={controls}
+          initial="normal"
+          variants={INDIAN_RUPEE_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M9 7a4 4 0 0 1 0 8H8l3 2"
+          animate={controls}
+          initial="normal"
+          variants={INDIAN_RUPEE_MAIN_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptIndianRupeeIcon.displayName = "ReceiptIndianRupeeIcon";
+
+export { ReceiptIndianRupeeIcon };

--- a/icons/receipt-japanese-yen.tsx
+++ b/icons/receipt-japanese-yen.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptJapaneseYenIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptJapaneseYenIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const JAPANESE_YEN_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const JAPANESE_YEN_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptJapaneseYenIcon = forwardRef<
+  ReceiptJapaneseYenIconHandle,
+  ReceiptJapaneseYenIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="m12 10 3-3"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_MAIN_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M9 11h6"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M9 15h6"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="m9 7 3 3v7"
+          animate={controls}
+          initial="normal"
+          variants={JAPANESE_YEN_MAIN_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptJapaneseYenIcon.displayName = "ReceiptJapaneseYenIcon";
+
+export { ReceiptJapaneseYenIcon };

--- a/icons/receipt-pound-sterling.tsx
+++ b/icons/receipt-pound-sterling.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptPoundSterlingIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+const POUND_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const POUND_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+interface ReceiptPoundSterlingIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ReceiptPoundSterlingIcon = forwardRef<
+  ReceiptPoundSterlingIconHandle,
+  ReceiptPoundSterlingIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M10 17V9.5a1 1 0 0 1 5 0"
+          animate={controls}
+          initial="normal"
+          variants={POUND_MAIN_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 13h5"
+          animate={controls}
+          initial="normal"
+          variants={POUND_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M8 17h7"
+          animate={controls}
+          initial="normal"
+          variants={POUND_SECONDARY_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptPoundSterlingIcon.displayName = "ReceiptPoundSterlingIcon";
+
+export { ReceiptPoundSterlingIcon };

--- a/icons/receipt-russian-ruble.tsx
+++ b/icons/receipt-russian-ruble.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptRussianRubleIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptRussianRubleIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const RUSSIAN_RUBLE_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const RUSSIAN_RUBLE_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptRussianRubleIcon = forwardRef<
+  ReceiptRussianRubleIconHandle,
+  ReceiptRussianRubleIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 11h5a2 2 0 0 0 0-4h-3v10"
+          animate={controls}
+          initial="normal"
+          variants={RUSSIAN_RUBLE_MAIN_VARIANTS}
+        />
+        <motion.path
+          d="M8 15h5"
+          animate={controls}
+          initial="normal"
+          variants={RUSSIAN_RUBLE_SECONDARY_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptRussianRubleIcon.displayName = "ReceiptRussianRubleIcon";
+
+export { ReceiptRussianRubleIcon };

--- a/icons/receipt-swiss-franc.tsx
+++ b/icons/receipt-swiss-franc.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptSwissFrancIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptSwissFrancIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const FRANC_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const FRANC_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptSwissFrancIcon = forwardRef<
+  ReceiptSwissFrancIconHandle,
+  ReceiptSwissFrancIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M10 11h4"
+          animate={controls}
+          initial="normal"
+          variants={FRANC_SECONDARY_VARIANTS}
+        />
+        <motion.path
+          d="M10 17V7h5"
+          animate={controls}
+          initial="normal"
+          variants={FRANC_MAIN_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        <motion.path
+          d="M8 15h5"
+          animate={controls}
+          initial="normal"
+          variants={FRANC_SECONDARY_VARIANTS}
+        />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptSwissFrancIcon.displayName = "ReceiptSwissFrancIcon";
+
+export { ReceiptSwissFrancIcon };

--- a/icons/receipt-text.tsx
+++ b/icons/receipt-text.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptTextIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptTextIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const LINES_CONTAINER_VARIANTS: Variants = {
+  visible: {
+    transition: { staggerChildren: 0.1, delayChildren: 0 },
+  },
+  hidden: {
+    transition: { staggerChildren: 0.06, staggerDirection: -1 },
+  },
+};
+
+const LINE_VARIANTS: Variants = {
+  visible: {
+    pathLength: 1,
+    opacity: 1,
+    transition: { duration: 0.35, ease: "linear" },
+  },
+  hidden: {
+    pathLength: 0,
+    opacity: 1,
+    transition: { duration: 0.2, ease: "linear" },
+  },
+};
+
+const ReceiptTextIcon = forwardRef<ReceiptTextIconHandle, ReceiptTextIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    const replayLines = useCallback(async () => {
+      await controls.start("hidden");
+      await controls.start("visible");
+    }, [controls]);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = ref != null;
+      return {
+        startAnimation: () => replayLines(),
+        stopAnimation: () => controls.start("visible"),
+      };
+    }, [controls, ref, replayLines]);
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          await replayLines();
+        }
+      },
+      [onMouseEnter, replayLines],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("visible");
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+          <motion.g
+            animate={controls}
+            initial="visible"
+            variants={LINES_CONTAINER_VARIANTS}
+          >
+            <motion.path d="M8 8H14" variants={LINE_VARIANTS} />
+            <motion.path d="M8 12H16" variants={LINE_VARIANTS} />
+            <motion.path d="M8 16H13" variants={LINE_VARIANTS} />
+          </motion.g>
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptTextIcon.displayName = "ReceiptTextIcon";
+
+export { ReceiptTextIcon };

--- a/icons/receipt-turkish-lira.tsx
+++ b/icons/receipt-turkish-lira.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptTurkishLiraIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptTurkishLiraIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const LIRA_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const LIRA_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptTurkishLiraIcon = forwardRef<
+  ReceiptTurkishLiraIconHandle,
+  ReceiptTurkishLiraIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("animate");
+      } else {
+        onMouseEnter?.(e);
+      }
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) {
+        controls.start("normal");
+      } else {
+        onMouseLeave?.(e);
+      }
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <motion.path
+          d="M10 7v10a5 5 0 0 0 5-5"
+          animate={controls}
+          initial="normal"
+          variants={LIRA_MAIN_VARIANTS}
+        />
+        <motion.path
+          d="m14 8-6 3"
+          animate={controls}
+          initial="normal"
+          variants={LIRA_SECONDARY_VARIANTS}
+        />
+        <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+      </motion.svg>
+    </div>
+  );
+});
+
+ReceiptTurkishLiraIcon.displayName = "ReceiptTurkishLiraIcon";
+
+export { ReceiptTurkishLiraIcon };

--- a/icons/receipt.tsx
+++ b/icons/receipt.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { motion, useAnimation, Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ReceiptIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ReceiptIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DOLLAR_MAIN_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    transition: {
+      duration: 0.6,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const DOLLAR_SECONDARY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+      opacity: { duration: 0.1, delay: 0.5 },
+    },
+  },
+};
+
+const ReceiptIcon = forwardRef<ReceiptIconHandle, ReceiptIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlledRef.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <motion.path
+            d="M12 17V7"
+            animate={controls}
+            initial="normal"
+            variants={DOLLAR_SECONDARY_VARIANTS}
+          />
+          <motion.path
+            d="M16 8h-6a2 2 0 0 0 0 4h4a2 2 0 0 1 0 4H8"
+            animate={controls}
+            initial="normal"
+            variants={DOLLAR_MAIN_VARIANTS}
+          />
+          <path d="M4 3a1 1 0 0 1 1-1 1.3 1.3 0 0 1 .7.2l.933.6a1.3 1.3 0 0 0 1.4 0l.934-.6a1.3 1.3 0 0 1 1.4 0l.933.6a1.3 1.3 0 0 0 1.4 0l.933-.6a1.3 1.3 0 0 1 1.4 0l.934.6a1.3 1.3 0 0 0 1.4 0l.933-.6A1.3 1.3 0 0 1 19 2a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1 1.3 1.3 0 0 1-.7-.2l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.934.6a1.3 1.3 0 0 1-1.4 0l-.933-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-1.4 0l-.934-.6a1.3 1.3 0 0 0-1.4 0l-.933.6a1.3 1.3 0 0 1-.7.2 1 1 0 0 1-1-1z" />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+ReceiptIcon.displayName = "ReceiptIcon";
+
+export { ReceiptIcon };


### PR DESCRIPTION
This PR introduces the fifth and final batch of animated Lucide icons with interaction-based animations such as hover, click, and appearance transitions.

Included Icons (Batch 5) :

41. receipt-indian-rupee
42. receipt-japanese-yen
43. receipt-pound-sterling
44. receipt-russian-ruble
45. receipt-swiss-franc
46. receipt-text
47. receipt-turkish-lira
48. receipt
49. receipt-cent
50. receipt-euro

 🎥 Demo

A demo video is attached showcasing the animations for the included icons.

All icons follow the existing project structure and animation patterns to maintain consistency across the library.

I sincerely apologize for initially submitting all icons in a single PR and for not including demo videos earlier. Thank you for your guidance — it really helped me improve how I structure contributions.

Please feel free to review and share any suggestions or improvements. I would be happy to refine any icons if needed.

If you would like more icons or additional variations, I would love to continue contributing.

Thank you so much for your time and quick responses — I truly appreciate it!

https://github.com/user-attachments/assets/80158f15-9456-4754-98fa-ce4fe6a0408d


